### PR TITLE
Gun Rebalancing - Rifles

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -11,11 +11,19 @@
         map: ["enum.GunVisualLayers.Base"]
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
+  - type: GunWieldBonus
+    minAngle: -20
+    maxAngle: -50
   - type: Gun
-    fireRate: 2
+    minAngle: 21
+    maxAngle: 54
+    angleIncrease: 6
+    angleDecay: 24
+    fireRate: 6
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+    - Burst
   - type: ChamberMagazineAmmoProvider
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -1,14 +1,13 @@
-# Used by the Vulcan, L6SAW, Mark 1, Ceremonial Mark 1, and the AKMS. Basically just all .30 rifles.
 - type: entity
   id: BulletHeavyRifle
-  name: bullet (.30 rifle)
+  name: bullet (.20 rifle)
   parent: BaseBullet
   noSpawn: true
   components:
   - type: Projectile
     damage:
       types:
-        Piercing: 24
+        Piercing: 19
 
 - type: entity
   id: BulletMinigun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -1,6 +1,7 @@
+# Used by the Vulcan, L6SAW, Mark 1, Ceremonial Mark 1, and the AKMS. Basically just all .30 rifles.
 - type: entity
   id: BulletHeavyRifle
-  name: bullet (.20 rifle)
+  name: bullet (.30 rifle)
   parent: BaseBullet
   noSpawn: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -1,3 +1,4 @@
+# pretty sure this is unused lmao
 - type: entity
   id: BulletHeavyRifle
   name: bullet (.20 rifle)
@@ -8,7 +9,7 @@
     damage:
       types:
         Piercing: 19
-
+# least minigun still exists
 - type: entity
   id: BulletMinigun
   name: minigun bullet (.10 rifle)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -8,7 +8,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 24
 
 - type: entity
   id: BulletMinigun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -55,4 +55,4 @@
       types:
         Radiation: 10
         Piercing: 5
-      ignoreResistances: true
+    ignoreResistances: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -1,17 +1,18 @@
+# Used by the Vulcan, L6SAW, Mark 1, Ceremonial Mark 1, and the AKMS. Basically just all .30 rifles.
 - type: entity
   id: BulletLightRifle
-  name: bullet (.20 rifle)
+  name: bullet (.30 rifle)
   parent: BaseBullet
   noSpawn: true
   components:
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 24
 
 - type: entity
   id: BulletLightRiflePractice
-  name: bullet (.20 rifle practice)
+  name: bullet (.30 rifle practice)
   parent: BaseBulletPractice
   noSpawn: true
   components:
@@ -22,7 +23,7 @@
 
 - type: entity
   id: BulletLightRifleRubber
-  name: bullet (.20 rifle rubber)
+  name: bullet (.30 rifle rubber)
   parent: BaseBulletRubber
   noSpawn: true
   components:
@@ -34,23 +35,24 @@
 - type: entity
   id: BulletLightRifleIncendiary
   parent: BaseBulletIncendiary
-  name: bullet (.20 rifle incendiary)
+  name: bullet (.30 rifle incendiary)
   noSpawn: true
   components:
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 16
+        Blunt: 5
+        Heat: 19
 
 - type: entity
   id: BulletLightRifleUranium
   parent: BaseBulletUranium
-  name: bullet (.20 rifle uranium)
+  name: bullet (.30 rifle uranium)
   noSpawn: true
   components:
   - type: Projectile
     damage:
       types:
-        Radiation: 9
-        Piercing: 10
+        Radiation: 10
+        Piercing: 5
+      ignoreResistances: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 24
 
 - type: entity
   id: BulletRiflePractice
@@ -40,9 +40,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
-        Heat: 15
-  
+        Blunt: 4
+        Heat: 20
+
 - type: entity
   id: BulletRifleUranium
   parent: BaseBulletUranium
@@ -52,6 +52,6 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 7
-        Piercing: 8
-        
+        Radiation: 10
+        Piercing: 5
+      ignoreResistances: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -54,4 +54,4 @@
       types:
         Radiation: 10
         Piercing: 5
-      ignoreResistances: true
+    ignoreResistances: true


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Bumps rifles to 24 total damage per shot, and gives uranium rounds armor penetration at the cost of only doing 15 damage.
Pretty much a copy of Grimbly [#34](https://github.com/Grimbly-Station/Grimbly-Station/pull/34) and [#45](https://github.com/Grimbly-Station/Grimbly-Station/pull/45)

Should **hopefully** make rifles not as horrible to use compared to SMGs or Shotguns. I hope.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

Nothing, I hope.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Ducks
- tweak: Rebalanced Rifle damages.
- tweak: Uranium rounds now pierce armor, but do less damage.