### PR TITLE
Makes Role Timers Not Shit

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -6,16 +6,15 @@
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobClerk
-      min: 36000 # 10 hours
+      min: 18000 # 5 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobLawyer
-      min: 36000 # 10 hours
+      min: 18000 # 5 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobProsecutor
-      min: 36000 # 10 hours
+      min: 18000 # 5 hours
     - !type:CharacterOverallTimeRequirement
-      min: 90000 # 25 hours
-    - !type:CharacterWhitelistRequirement # whitelist requirement because I don't want any dingus judges
+      min: 54000 # 15 hours
   weight: 20
   startingGear: CJGear
   icon: "JobIconChiefJustice"

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/clerk.yml
@@ -7,13 +7,13 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
-      min: 36000 # 10 hrs
+      min: 18000 # 5 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobLawyer
-      min: 36000 # 10 hours
+      min: 10800 # 3 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobProsecutor
-      min: 36000 # 10 hours
+      min: 18000 # 5 hours
 
 
   startingGear: ClerkGear

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/prosecutor.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobProsecutor
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 36000 # 10 hrs
+      min: 18000 # 5 hrs
   startingGear: ProsecutorGear
   icon: "JobIconProsecutor"
   supervisors: job-supervisors-cj

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Medical/medical_borg.yml
@@ -6,7 +6,7 @@
   playTimeTracker: JobMedicalBorg
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 216000 #60 hrs
+      min: 180000 #30 hrs - same as normal borg
     - !type:DepartmentTimeRequirement
       department: Medical
       min: 21600 #6 hrs

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
-      min: 21600 # 6 hrs
+      min: 18000 # 4 hrs
     - !type:DepartmentTimeRequirement
       department: Security
       min: 18000 # 4 hrs

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -6,4 +6,4 @@
   objective: roles-antag-space-ninja-objective
   requirements:
   - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-    min: 259200 # DeltaV - 72 hours
+    min: 72000 # goob mrp - 20 hours - NOBODY IS PLAYING FUCKING 72 HOURS FOR NINJA :sob:

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -1,3 +1,5 @@
+# evil gang :interrobang:
+
 - type: antag
   id: Nukeops
   name: roles-antag-nuclear-operative-name
@@ -6,10 +8,7 @@
   objective: roles-antag-nuclear-operative-objective
   requirements:
   - !type:CharacterOverallTimeRequirement
-    min: 108000 # DeltaV - 30 hours
-  - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
-    department: Security
-    min: 36000 # DeltaV - 10 hours
+    min: 54000 # goob mrp - 15 hours
 
 - type: antag
   id: NukeopsMedic
@@ -19,10 +18,10 @@
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:CharacterOverallTimeRequirement
-    min: 108000 #  30 hours
+    min: 54000 # goob mrp - 15 hours
   - !type:CharacterDepartmentTimeRequirement
     department: Medical
-    min: 36000 # 10 hours
+    min: 18000 # 5 hours
 
 - type: antag
   id: NukeopsCommander
@@ -32,15 +31,16 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:CharacterOverallTimeRequirement
-    min: 216000 # DeltaV - 60 hours
+    min: 108000 # goob mrp - 30 hours
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
     department: Security
-    min: 36000 # DeltaV - 10 hours
+    min: 10800 # goob mrp - 3 hours
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
     department: Command
-    min: 36000 # DeltaV - 10 hours
-  - !type:CharacterWhitelistRequirement
+    min: 10800 # goob mrp - 3 hours
 
+    # needing whitelist to be nukie commander was fucking stupid im glad i dont play delta
+    
 #Lone Operative Gear
 - type: startingGear
   id: SyndicateLoneOperativeGearFull

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -6,10 +6,7 @@
   objective: roles-antag-rev-head-objective
   requirements:
   - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-    min: 172800 # DeltaV - 48 hours
-  - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
-    department: Command
-    min: 36000 # DeltaV - 10 hours
+    min: 72000 # goob mrp - 20 hours
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -6,4 +6,4 @@
   objective: roles-antag-syndicate-agent-objective
   requirements:
   - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-    min: 86400 # DeltaV - 24 hours
+    min: 10800 # goob mrp - 3 hours

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -6,7 +6,7 @@
   objective: roles-antag-initial-infected-objective
   requirements:
   - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-    min: 43200 # DeltaV - 12 hours
+    min: 18000 # goob mrp - 5 hours
 
 - type: antag
   id: Zombie

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -16,9 +16,9 @@
       min: 7200 # 2 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 43200 #DeltaV 12 hours
+      min: 21600 #goob mrp 6 hours
     - !type:CharacterOverallTimeRequirement
-      min: 144000 #40 hrs
+      min: 72000 #goob mrp 20 hrs
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -7,7 +7,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 21600 #DeltaV 6 hrs
+      min: 10800 #goob mrp 3 hrs
   #  - !type:OverallPlaytimeRequirement #DeltaV
   #    time: 36000 #10 hrs
   icon: "JobIconShaftMiner"

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -9,10 +9,6 @@
       min: 7200 # 2 hours
     - !type:CharacterLogicOrRequirement
       requirements:
-        - !type:CharacterSpeciesRequirement
-          inverted: true
-          species:
-            - IPC
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # Chaplain is now one of the station's "Crew-Aligned Wizards"
-      min: 14400 # 4 hours
+      min: 7200 # 2 hours
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -9,6 +9,10 @@
       min: 7200 # 2 hours
     - !type:CharacterLogicOrRequirement
       requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - IPC
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobClown
   requirements:
     - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-      min: 7200 #2 hrs
+      min: 3600 #1 hrs
   startingGear: ClownGear
   icon: "JobIconClown"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -6,10 +6,10 @@
   antagAdvantage: 2 # DeltaV - Reduced TC: Security Radio and Access
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 36000 # 10 hrs
+      min: 18000 # 5 hrs
     - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
       department: Security
-      min: 14400 # 4 hours
+      min: 7200 # 2 hours
   startingGear: LawyerGear
   icon: "JobIconLawyer"
   supervisors: job-supervisors-cj  # Delta V - Change supervisor to chief justice

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobMusician
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 7200 # DeltaV - 2 hours
+      min: 1800 # goob mrp - 0.5 hours
   startingGear: MusicianGear
   icon: "JobIconMusician"
   supervisors: job-supervisors-hire

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobServiceWorker
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 7200 # DeltaV - 2 hours
+      min: 1800 # goob mrp - 0.5 hours
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -6,25 +6,24 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 18000 # DeltaV - 5 hours
+      min: 10800 # goob mrp - 3 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Engineering
-      min: 18000 # DeltaV - 5 hours
+      min: 10800 # goob mrp - 3 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Medical
-      min: 18000 # DeltaV - 5 hours
+      min: 10800 # goob mrp - 3 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Security
-      min: 18000 # DeltaV - 5 hours
+      min: 10800 # goob mrp - 3 hours
     - !type:CharacterDepartmentTimeRequirement # DeltaV - Epistemics dept time requirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 18000 # 5 hours
+      min: 10800 # goob mrp - 3 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Command
-      min: 108000 # DeltaV - 30 hours
+      min: 54000 # 15 hours
     - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-      min: 108000 # 30 hours
-    - !type:CharacterWhitelistRequirement
+      min: 54000 # 15 hours
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -7,18 +7,18 @@
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobChef
-      min: 14400 # DeltaV - 4 hours
+      min: 3600 # goob mrp - 1 hour
     - !type:CharacterPlaytimeRequirement
       tracker: JobBartender
-      min: 14400 # DeltaV - 4 hours
+      min: 3600 # goob mrp - 1 hour
     - !type:CharacterPlaytimeRequirement
       tracker: JobJanitor
-      min: 14400 # DeltaV - 4 hours
+      min: 3600 # goob mrp - 1 hour
     - !type:CharacterDepartmentTimeRequirement # DeltaV - Civilian dept time requirement
       department: Civilian
-      min: 72000 # 20 hours
+      min: 36000 # 10 hours
     - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
-      min: 90000 # 25 hours
+      min: 36000 # 10 hours
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -7,7 +7,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Engineering
-      min: 36000 # DeltaV - 10 hours
+      min: 18000 # DeltaV - 5 hours
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -6,13 +6,13 @@
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobAtmosphericTechnician
-      min: 36000 # DeltaV - 10 hours
+      min: 10800 # goob mrp - 3 hours
 #    - !type:RoleTimeRequirement # DeltaV - No Station Engineer time requirement
 #      role: JobStationEngineer
 #      time: 21600 #6 hrs
     - !type:CharacterDepartmentTimeRequirement
       department: Engineering
-      min: 90000 # DeltaV - 25 hours
+      min: 54000 # goob mrp - 15 hours - i would've set this to 10 but there are too many fucking CEs that have no idea how engi works
 #    - !type:OverallPlaytimeRequirement
 #      time: 72000 # DeltaV - 20 hours
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/senior_engineer.yml
@@ -13,7 +13,7 @@
       min: 21600 #6 hrs
     - !type:CharacterDepartmentTimeRequirement
       department: Engineering
-      min: 216000 # 60 hrs
+      min: 108000 # 30 hrs
   startingGear: SeniorEngineerGear
   icon: "JobIconSeniorEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -7,7 +7,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Engineering
-      min: 14400 #4 hrs
+      min: 7200 #2 hrs
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -6,7 +6,7 @@
   antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
   requirements:
   - !type:CharacterOverallTimeRequirement # DeltaV - to prevent griefers from taking the role.
-      min: 14400 # 4 hours
+      min: 3600 # 1 hours
     # - !type:DepartmentTimeRequirement # DeltaV - Removes time limit
     #   department: Engineering
     #   time: 54000 #15 hrs
@@ -27,6 +27,7 @@
     back: ClothingBackpackEngineeringFilled
     shoes: ClothingShoesBootsWork
     id: TechnicalAssistantPDA
+    eyes: ClothingEyesGlassesMeson
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
     pocket2: BookEngineersHandbook

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -14,7 +14,7 @@
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering
-  canBeAntag: true # DeltaV - Can be antagonist
+  canBeAntag: false # goob mrp - shouldn't be antag, its a training role
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Medical
-      min: 28800 # DeltaV - 8 hours
+      min: 14400 # goob mrp - 4 hours
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,9 +15,9 @@
 #      time: 21600 #6 hrs
     - !type:CharacterDepartmentTimeRequirement
       department: Medical
-      min: 43200 # DeltaV - 12 hours
+      min: 36000 # goob mrp - 10 hours
     - !type:CharacterOverallTimeRequirement
-      min: 72000 # DeltaV - 20 hours
+      min: 36000 # goob mrp - 10 hours
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Medical
-      min: 14400 #4 hrs
+      min: 7200 #2 hrs
   startingGear: DoctorGear
   icon: "JobIconMedicalDoctor"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -11,7 +11,7 @@
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine
-  canBeAntag: true # DeltaV - Can be antagonist
+  canBeAntag: false # goob mrp - training role
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -10,7 +10,7 @@
     #   time: 14400 #4 hrs
     - !type:CharacterDepartmentTimeRequirement # DeltaV - Medical dept time requirement
       department: Medical
-      min: 28800 # DeltaV - 8 hours
+      min: 14400 # goob mrp - 4 hours
     # - !type:OverallPlaytimeRequirement # DeltaV - No playtime requirement
     #   time: 54000 # 15 hrs
   startingGear: ParamedicGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/senior_physician.yml
@@ -13,7 +13,7 @@
       min: 21600 #6 hrs
     - !type:CharacterDepartmentTimeRequirement
       department: Medical
-      min: 216000 # 60 hrs
+      min: 108000 # 30 hrs
   startingGear: SeniorPhysicianGear
   icon: "JobIconSeniorPhysician"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobBorg
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 216000 #60 hrs
+      min: 108000 #30 hrs - still making this 30 hours instead of something reasonable, silicon laws are really fucky - not for the new goober..
   canBeAntag: false
   icon: JobIconBorg
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -11,7 +11,7 @@
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science
-  canBeAntag: true # DeltaV - Can be antagonist
+  canBeAntag: false # goob mrp - training role
   access:
   - Research
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -7,9 +7,9 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 54000 # DeltaV - 15 hours
+      min: 3600 # goob mrp - 10 hours
     - !type:CharacterOverallTimeRequirement
-      min: 72000 # DeltaV - 20 hours
+      min: 3600 # goob mrp - 10 hours
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
@@ -6,7 +6,7 @@
   requirements:
   - !type:CharacterDepartmentTimeRequirement
     department: Epistemics
-    min: 14400 # 4 hours - same as scientist
+    min: 7200 # 2 hours - same as scientist
   startingGear: RoboticistGear
   icon: "JobIconRoboticist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 14400 #4 hrs
+      min: 7200 # 2 hours
   startingGear: ScientistGear
   icon: "JobIconScientist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/senior_researcher.yml
@@ -7,7 +7,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 216000 #60 hrs
+      min: 108000 #30 hrs
   startingGear: SeniorResearcherGear
   icon: "JobIconSeniorResearcher"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -6,7 +6,7 @@
   requirements:
   - !type:CharacterDepartmentTimeRequirement
     department: Security
-    min: 36000 # DeltaV - 10 hours
+    min: 18000 # goob mrp - 50 hours
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,16 +6,18 @@
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobWarden
-      min: 14400 #DeltaV 4 hrs
+      min: 10800 #goob mrp 3 hrs
   #  - !type:RoleTimeRequirement # DeltaV - No Security Officer time requirement - REIMPLEMENT WHEN MORE PEOPLE HAVE IT
   #    role: JobDetective
   #    time: 14400 #DeltaV 4 hrs
-    - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
+    - !type:CharacterDepartmentTimeRequirement # goob mrp - Command dept time requirement
       department: Command
+      min: 7200 # 2 hours
+    - !type:CharacterDepartmentTimeRequirement # goob mrp - sec dept time requirement
+      department: Security
       min: 36000 # 10 hours
     - !type:CharacterOverallTimeRequirement
-      min: 90000 # DeltaV - 25 hours
-    - !type:CharacterWhitelistRequirement
+      min: 72000 # goob mrp - 20 hours
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,11 +6,10 @@
   requirements:
     - !type:CharacterPlaytimeRequirement # DeltaV - JobSecurityOfficer time requirement. Make them experienced in proper officer work.
       tracker: JobSecurityOfficer
-      min: 43200 # DeltaV - 12 hrs
+      min: 28800 # goob mrp - 8 hrs
     - !type:CharacterPlaytimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
       tracker: JobDetective
       min: 14400 # DeltaV - 4 hours
-    - !type:CharacterWhitelistRequirement
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobBoxer
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 7200 #DeltaV 2 hours
+      min: 3600 #goob mrp 1 hours
   startingGear: BoxerGear
   icon: "JobIconBoxer"
   supervisors: job-supervisors-hop

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/psychologist.yml
@@ -5,10 +5,10 @@
   playTimeTracker: JobPsychologist
   requirements:
     - !type:CharacterOverallTimeRequirement
-      min: 36000 #DeltaV 10 hours
+      min: 7200 #goob mrp 2 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Medical
-      min: 14400 #DeltaV 4 hrs
+      min: 3600 #goob mrp 1 hrs
   startingGear: PsychologistGear
   icon: "JobIconPsychologist"
   supervisors: job-supervisors-cmo


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

- Dude who the fuck is playing 72 hours for space ninja??
- Why can training roles become antags?
- Whitelists for cap warden hos (and nukie commander) when the server struggled to have all 3 even without role timers??
- Command will be completely empty every round with the current timers

This fixes that all using a revolutionary technique called Changing Numbers in yamls

<details><summary><h1>Media</h1></summary>
<p>

no media needed loser all it is is edited numbers

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: starch
- tweak: changed role-timers to be more fitting for the shittery
