### PR TITLE
[Port] Add Different Launch Types to VSCode (#1430)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        // CLIENT CONFIGS
         {
             "name": "Client",
             "type": "coreclr",
@@ -14,7 +15,28 @@
             "stopAtEntry": false
         },
         {
-            "name": "Client (Compatibility renderer)",
+            "name": "Client (Tools)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build (Tools)",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Client (Release)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build (Release)",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        // COMPATABILITY RENDERERS
+        {
+            "name": "Client (Compatibility Renderer)",
             "type": "coreclr",
             "request": "launch",
             "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
@@ -22,6 +44,27 @@
             "console": "internalConsole",
             "stopAtEntry": false
         },
+        {
+            "name": "Client (Tools) - (Compatability Renderer)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build (Tools)",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": ["--cvar display.compat=true"],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Client (Release) - (Compatability Renderer)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build (Release)",
+            "program": "${workspaceFolder}/bin/Debug/Content.Client/Content.Client.dll",
+            "args": ["--cvar display.compat=true"],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        // SERVER CONFIGS
         {
             "name": "Server",
             "type": "coreclr",
@@ -31,6 +74,27 @@
             "console": "integratedTerminal",
             "stopAtEntry": false
         },
+        {
+            "name": "Server (Tools)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build (Tools)",
+            "program": "${workspaceFolder}/bin/Content.Server/Content.Server.dll",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Server (Release)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build (Release)",
+            "program": "${workspaceFolder}/bin/Content.Server/Content.Server.dll",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        // LINTER
         {
             "name": "YAML Linter",
             "type": "coreclr",
@@ -50,6 +114,22 @@
                 "Client"
             ],
             "preLaunchTask": "build"
+        },
+        {
+            "name": "Server/Client (Tools)",
+            "configurations": [
+                "Server (Tools)",
+                "Client (Tools)"
+            ],
+            "preLaunchTask": "build (Tools)"
+        },
+        {
+            "name": "Server/Client (Release)",
+            "configurations": [
+                "Server (Release)",
+                "Client (Release)"
+            ],
+            "preLaunchTask": "build (Release)"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,46 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "build (Tools)",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "--configuration",
+                "Tools",
+                "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
+                "/consoleloggerparameters:NoSummary" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build (Release)",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "--configuration",
+                "Release",
+                "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
+                "/consoleloggerparameters:NoSummary" // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "build-yaml-linter",
             "command": "dotnet",
             "type": "process",


### PR DESCRIPTION
# Description
This adds several different launch types to the VSCode. This allows you to launch Client in Compatibility Mode for the Tools/Release versions as well as launch the Server/Client at the same time in Tools/Release modes and use the VSCode Terminal.

---

# TODO
- [x] Add different Build types in the tasks.json file.
- [x] Add different Launch types in the launch.json file.

---


![image](https://github.com/user-attachments/assets/c7ba1f8b-82e8-4f3c-9c19-cfc3d12cc978)