### PR TITLE
Gun Rebalancing Pt. 2 - Literally Everything Else (I Think)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -8,6 +8,6 @@
     damage:
       types:
         Piercing: 40
-        Structural: 30
+        Structural: 150  # Goob Station MRP - buff damage
   - type: StaminaDamageOnCollide
     damage: 35

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -8,8 +8,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
-# least minigun still exists
+        Piercing: 24  # Goob Station MRP - buff damage
+
 - type: entity
   id: BulletMinigun
   name: minigun bullet (.10 rifle)
@@ -19,4 +19,4 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 5
+        Piercing: 24  # Goob Station MRP - buff damage

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -8,7 +8,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 24
+        Piercing: 24 # Goob Station MRP - buff damage
 
 - type: entity
   id: BulletLightRiflePractice
@@ -41,8 +41,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 5
-        Heat: 19
+        Blunt: 4 # Goob Station MRP - buff Blunt/Heat damage
+        Heat: 20
 
 - type: entity
   id: BulletLightRifleUranium
@@ -55,4 +55,4 @@
       types:
         Radiation: 10
         Piercing: 5
-    ignoreResistances: true
+    ignoreResistances: true # Goob Station MRP - ignore resistances

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 20 # Goob Station MRP - buff damage
 
 - type: entity
   id: BulletPistolPractice
@@ -41,7 +41,7 @@
     damage:
       types:
         Blunt: 2
-        Heat: 14
+        Heat: 18 # Goob Station MRP - buff damage
 
 - type: entity
   id: BulletPistolUranium
@@ -49,8 +49,9 @@
   name: bullet (.35 auto uranium)
   categories: [ HideSpawnMenu ]
   components:
-  - type: Projectile
+  - type: Projectile # Goob Station - ignore resistances
     damage:
       types:
-        Radiation: 6
+        Radiation: 5
         Piercing: 10
+    ignoreResistances: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 24
+        Piercing: 24 # Goob Station MRP - buff damage
 
 - type: entity
   id: BulletRiflePractice
@@ -38,7 +38,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
-    damage:
+    damage: # Goob Station MRP - buff damage
       types:
         Blunt: 4
         Heat: 20
@@ -49,7 +49,7 @@
   name: bullet (0.20 rifle uranium)
   categories: [ HideSpawnMenu ]
   components:
-  - type: Projectile
+  - type: Projectile # Goob Station MRP - ignore resistances
     damage:
       types:
         Radiation: 10

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -10,7 +10,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28
+        Piercing: 40 # Goob Station MRP - buff damage
 
 - type: entity
   id: PelletShotgunBeanbag
@@ -50,7 +50,7 @@
   - type: ProjectileSpread
     proto: PelletShotgun
     count: 6
-    spread: 15
+    spread: 10 # Goob Station MRP - tighten up the spread
 
 - type: entity
   id: PelletShotgunIncendiary
@@ -77,7 +77,7 @@
   - type: ProjectileSpread
     proto: PelletShotgunIncendiary
     count: 6
-    spread: 15
+    spread: 10 # Goob Station MRP - tighten up the spread
 
 - type: entity
   id: PelletShotgunPractice
@@ -101,7 +101,7 @@
   - type: ProjectileSpread
     proto: PelletShotgunPractice
     count: 6
-    spread: 15
+    spread: 10 # Goob Station MRP - tighten up the spread
 
 - type: entity
   id: PelletShotgunImprovised
@@ -211,11 +211,12 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
     state: depleted-uranium
-  - type: Projectile
+  - type: Projectile # Goob Station - ignore resistances
     damage:
       types:
         Radiation: 5
-        Piercing: 5
+        Piercing: 2.5
+    ignoreResistances: true
 
 - type: entity
   id: PelletShotgunUraniumSpread

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -20,7 +20,7 @@
   id: RedLaser
   damage:
     types:
-      Heat: 14
+      Heat: 20 # Goob Station MRP - buff damage
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -50,7 +50,7 @@
   id: RedMediumLaser
   damage:
     types:
-      Heat: 17
+      Heat: 24 # Goob Station MRP - buff damage
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -81,7 +81,7 @@
   damage:
     types:
       Heat: 10
-      Radiation: 10
+      Radiation: 15 # Goob Station MRP - buff damage
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_xray
@@ -96,7 +96,7 @@
   id: RedHeavyLaser
   damage:
     types:
-      Heat: 28
+      Heat: 30 # Goob Station MRP - buff damage
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -111,7 +111,7 @@
   id: Pulse
   damage:
     types:
-      Heat: 35
+      Heat: 45 # Goob Station MRP - buff damage
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_blue


### PR DESCRIPTION
# Description

Snagged the rest of the buffs from Spacious Station, and buffed shotguns and lasers.
The gap between Rifles and SMGs closes a bit more once more, although rifles still have the damage advantage.

---

# TODO

- [x] Cry, as rifles lose part of their grasp with the best per shot damage for crew.
- [ ] Get feedback.
---

# Changelog

:cl:
- tweak: Most guns have been buffed.
- tweak: Most uranium munitions pierce armor.
