### PR TITLE
Mantis Cannot Be Antag & Intern Roles Can

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -21,8 +21,8 @@
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"
   supervisors: job-supervisors-rd
-  antagAdvantage: 5 # DeltaV - From 4 to 5
-  canBeAntag: true # DeltaV - Mantis is no longer a Detective
+  # antagAdvantage: 5 # [DeltaV - From 4 to 5] Goobstation - Removed since cannot be an antag
+  canBeAntag: false # Goobstation - Mantis is acting as a second-in-command and should not be an antag
   # whitelistRequired: true
   access:
   - Research

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -14,7 +14,7 @@
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering
-  canBeAntag: false # goob mrp - shouldn't be antag, its a training role
+  canBeAntag: true # Goobstation - Reset to True (Starch had it set to false)
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -11,7 +11,7 @@
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine
-  canBeAntag: false # goob mrp - training role
+  canBeAntag: true # Goobstation - Reset to true (Starch had it set to false)
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -11,7 +11,7 @@
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science
-  canBeAntag: false # goob mrp - training role
+  canBeAntag: true # Goobstation - Reset back to True (Starch had set it to false)
   access:
   - Research
   - Maintenance


### PR DESCRIPTION
# Description
This reverts part of PR #12 where Starch made it so intern roles cannot be antags. Limiting antag to non-intern roles is something that shouldn't exist. If you don't want to antag in an intern role, then you should _**disable**_ the Antag Selections. Simple as.

This also limits Mantis from being an antag due to its roundstart gift of Mindbreaking medications and because it is basically a 

---

# TODO
- [x] Make Technical, Medical, and Research roles that can be antags.
- [x] Make Mantis no longer possible to be an antag.

---

# Changelog
:cl:
- tweak: Intern roles in Engineering, Medical, and Epistemics can be Antags again.
- tweak: Mantis cannot be an Antag any longer.
