### PR TITLE
Erm.... No More Foreigner Trait Head Roles!!!!!

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -18,6 +18,7 @@
        - Muted
        - Blindness
        - Pacifist
+       - BrittleBoneDisease
   startingGear: CorpsmanGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -10,6 +10,14 @@
     - !type:DepartmentTimeRequirement
       department: Security
       min: 18000 # 4 hrs
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   startingGear: CorpsmanGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -26,7 +26,6 @@
        - ForeignerLight
        - Muted
        - Blindness
-       - Pacifist
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -19,6 +19,14 @@
       min: 21600 #goob mrp 6 hours
     - !type:CharacterOverallTimeRequirement
       min: 72000 #goob mrp 20 hrs
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -24,6 +24,14 @@
       min: 54000 # 15 hours
     - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
       min: 54000 # 15 hours
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   weight: 20
   startingGear: CaptainGear
   icon: JobIconCaptain

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -32,6 +32,7 @@
        - Muted
        - Blindness
        - Pacifist
+       - BrittleBoneDisease
   weight: 20
   startingGear: CaptainGear
   icon: JobIconCaptain

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -26,7 +26,6 @@
        - ForeignerLight
        - Muted
        - Blindness
-       - Pacifist
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -19,6 +19,14 @@
       min: 36000 # 10 hours
     - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
       min: 36000 # 10 hours
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -15,6 +15,14 @@
       min: 54000 # goob mrp - 15 hours - i would've set this to 10 but there are too many fucking CEs that have no idea how engi works
 #    - !type:OverallPlaytimeRequirement
 #      time: 72000 # DeltaV - 20 hours
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -22,7 +22,6 @@
        - ForeignerLight
        - Muted
        - Blindness
-       - Pacifist
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -18,6 +18,14 @@
       min: 36000 # goob mrp - 10 hours
     - !type:CharacterOverallTimeRequirement
       min: 36000 # goob mrp - 10 hours
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
 
 
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -25,9 +25,6 @@
        - ForeignerLight
        - Muted
        - Blindness
-       - Pacifist
-
-
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -26,7 +26,6 @@
             - ForeignerLight
             - Muted
             - Blindness
-            - Pacifist
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -19,6 +19,14 @@
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics
+        - !type:CharacterTraitRequirement
+          inverted: true    
+          traits:
+            - Foreigner
+            - ForeignerLight
+            - Muted
+            - Blindness
+            - Pacifist
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -13,6 +13,8 @@
       - Foreigner
       - ForeignerLight
       - Muted
+      - Blindness
+      - Pacifist
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -7,6 +7,12 @@
   - !type:CharacterDepartmentTimeRequirement
     department: Security
     min: 18000 # goob mrp - 50 hours
+  - !type:CharacterTraitRequirement
+    inverted: true    
+    traits:
+      - Foreigner
+      - ForeignerLight
+      - Muted
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -15,6 +15,7 @@
       - Muted
       - Blindness
       - Pacifist
+      - BrittleBoneDisease
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -23,6 +23,7 @@ r- type: job
       traits:
        - Foreigner
        - ForeignerLight
+       - Muted
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -1,4 +1,4 @@
-r- type: job
+- type: job
   id: HeadOfSecurity
   name: job-name-hos
   description: job-description-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -26,6 +26,7 @@
        - Muted
        - Blindness
        - Pacifist
+       - BrittleBoneDisease
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -24,6 +24,8 @@ r- type: job
        - Foreigner
        - ForeignerLight
        - Muted
+       - Blindness
+       - Pacifist
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -18,6 +18,10 @@
       min: 36000 # 10 hours
     - !type:CharacterOverallTimeRequirement
       min: 72000 # goob mrp - 20 hours
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - AnomalousPositronics
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -1,4 +1,4 @@
-- type: job
+r- type: job
   id: HeadOfSecurity
   name: job-name-hos
   description: job-description-hos
@@ -21,7 +21,8 @@
     - !type:CharacterTraitRequirement
       inverted: true    
       traits:
-       - AnomalousPositronics
+       - Foreigner
+       - ForeignerLight
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -18,6 +18,7 @@
        - Muted
        - Blindness
        - Pacifist
+       - BrittleBoneDisease
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -16,6 +16,8 @@
        - Foreigner
        - ForeignerLight
        - Muted
+       - Blindness
+       - Pacifist
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -10,6 +10,12 @@
 #      department: Security
 #      time: 54000 #15 hrs
 #      inverted: true # stop playing intern if you're good at security!
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -6,6 +6,14 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Security
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -14,6 +14,7 @@
        - Muted
        - Blindness
        - Pacifist
+       - BrittleBoneDisease
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -17,6 +17,14 @@
     - !type:CharacterDepartmentTimeRequirement
       department: Security
       min: 216000 # 60 hrs
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -25,6 +25,7 @@
        - Muted
        - Blindness
        - Pacifist
+       - BrittleBoneDisease
   startingGear: SeniorOfficerGear
   icon: "JobIconSeniorOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -10,6 +10,14 @@
     - !type:CharacterPlaytimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
       tracker: JobDetective
       min: 14400 # DeltaV - 4 hours
+    - !type:CharacterTraitRequirement
+      inverted: true    
+      traits:
+       - Foreigner
+       - ForeignerLight
+       - Muted
+       - Blindness
+       - Pacifist
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -18,6 +18,7 @@
        - Muted
        - Blindness
        - Pacifist
+       - BrittleBoneDisease
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
# Description

This PR prevents heads of staff and security members from having foreigner traits, muted trait, blindness trait, and pacifist trait (only HoS & Cap cannot be pacifist). These traits are major disabilities and actively detrimental to their departments & the rest of command staff if they have them. These traits make them unable to clearly and effectively communicate or render them unable to do a critical part of their jobs in the case of pacifist and muted.

---

# TODO

- [x] Security Department can no longer have pacifist, muted, blind, brittle bone disease, or foreigner traits.
- [x] Head of Security can no longer have pacifist, muted, blind, brittle bone disease, or foreigner traits.
- [x] Heads of staff can no longer have muted, blind, or foreigner traits.
- [x] The Captain can no longer have pacifist, muted, blind, brittle bone disease, or foreigner traits.
- [x] Head of Personnel can no longer have muted, blind, or foreigner traits.

---

# Changelog

:cl: ShirouAjisai
- tweak: Security Department can no longer have pacifist, muted, blind, brittle bone disease, or foreigner traits.
- tweak: Head of Security can no longer have pacifist, muted, blind, brittle bone disease, or foreigner traits.
- tweak: Heads of staff can no longer have muted, blind, or foreigner traits.
- tweak: The Captain can no longer have pacifist, muted, blind, brittle bone disease, or foreigner traits.
- tweak: The Head of Personnel can no longer have muted, blind, or foreigner traits.