### PR TITLE
Mantis Violence Update

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -18,9 +18,7 @@
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics
-        - !type:CharacterTraitRequirement
-          inverted: true    
-          traits:
+          inverted: true
             - Pacifist
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -18,6 +18,10 @@
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics
+        - !type:CharacterTraitRequirement
+          inverted: true    
+          traits:
+            - Pacifist
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"
   supervisors: job-supervisors-rd


### PR DESCRIPTION
Mantis can no longer be a pacifist

# Description

Mantis can no longer be a pacifist. His job is quite violent in nature at times and being a pacifist basically renders him useless seeing as he's given a gun, a knife, and with pacifism can't even use a syringe gun.

---

# TODO

- [x] Disable pacifism for the Mantis 

---

# Changelog

:cl: ShirouAjisai
- tweak: Mantis can no longer be a pacifist