### PR TITLE
Make HoP Great Again! (Give Accesses Back)

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -34,25 +34,11 @@
   - Janitor
   - Theatre
   - Kitchen
-#  - Chapel
   - Hydroponics
   - External
   - Cryogenics
-  # I mean they'll give themselves the rest of the access levels *anyways*.
-  # As of 15/03/23 they can't do that so here's MOST of the rest of the access levels.
-  # Head level access that isn't their own was deliberately left out, get AA from the captain instead.
-  # Delta V - fuck all of this HoP is a service role
-#  - Chemistry
-#  - Engineering
-#  - Research
-#  - Detective
-#  - Salvage
-#  - Security # NoooOoOo!! My HoPcurity!1
-#  - Brig
   - Lawyer
   - Cargo
-#  - Atmospherics
-#  - Medical
   - Boxer # DeltaV - Add Boxer access
   - Clown # DeltaV - Add Clown access
   - Library # DeltaV - Add Library access
@@ -60,6 +46,22 @@
   - Musician # DeltaV - Add Musician access
   - Reporter # DeltaV - Add Reporter access
   - Zookeeper # DeltaV - Add Zookeeper access
+  # Goobstation Additions (Re-Adding them back cause screw Delta-V Rules :3)
+  - Atmospherics
+  - Medical
+  - Chemistry
+  - Engineering
+  - Research
+  - Detective
+  - Salvage
+  - Security
+  - Chapel
+  - Corpsman
+  - Paramedic # DeltaV - Add Paramedic acces
+  - Psychologist # DeltaV - Add Psychologist access
+  - Mail # Nyanotrasen Addition for Courier
+  - Orders # DeltaV - Add Order access
+#  - Brig # - Delta-V removed Brig
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
# Description
This is a remake of PR #37.

This adds Pseudo-All Access back to HoP. They now have accesses to every department with some minor exceptions for Mantis and everything Justice Department related (since those will be removed). They also do not have access to Armory (as they should).

---

# TODO
This section shows the TODO for each individual department. Figured I'd add it to make it better to branch out.
- [x] Add Security basics (no Armory).
- [x] Add Cargo department accesses (including Orders and Courier/Mail).
- [x] Add Epistemics basics (no Mantis).
- [x] Add Engineering and Atmos.
- [x] Add Medical and individual accesses for it as well.

---

# Media
Screenshots of the ID card and Role Accesses (since ID card is based off them) for proof of working system.
<details><summary><h1>Accesses</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/803593ac-edd9-4462-98c4-20c768007a3c)
![image](https://github.com/user-attachments/assets/ce1ddeda-15b9-49a6-a3b7-24c386948208)

</p>
</details>

---

# Changelog
:cl:
- tweak: Make HoP Great Again! (They now have Access to all Departments except Mantis and Armory and Heads of Staff.)