### PR TITLE
(Attempt #2) Remove Prisoner Pacification, Add Tracking Implant

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -14,9 +14,11 @@
       department: Security
       min: 21600
   special:
-  - !type:AddComponentSpecial
-    components:
-      - type: Pacified
+  # - !type:AddComponentSpecial # Goobstation - remove PacifiedComponent from prisoners
+  #   components:
+  #     - type: Pacified
+  - !type:AddImplantSpecial # Goobstation - add tracking implant to prisoners
+    implants: [ TrackingImplant ]
 
 - type: startingGear
   id: PrisonerGear


### PR DESCRIPTION
# Description

Remove the pacification from prisoners, in exchange for giving them a tracking implant to allow them to be located when Security needs to track them down.

## Why / Balance

@CerberusWolfie said they liked this idea because it's much more open.

# Changelog

:cl: Skubman
- tweak: Removed the Pacifier implant from prisoners, and in exchange giving them a Tracking implant so their location can be tracked at all times.