### PR TITLE
Major SOP Update, Check Description

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/guidebook/sop.ftl
+++ b/Resources/Locale/en-US/_Goobstation/guidebook/sop.ftl
@@ -1,14 +1,15 @@
 # Goob SOP
 # - Main Directories
 guide-entry-sop = SOP
-guide-entry-sop-alert-levels = _Alert Levels
-guide-entry-sop-emergencies = _Emergencies
+guide-entry-sop-alert-levels = Alert Levels
+guide-entry-sop-emergencies = Emergencies
 guide-entry-sop-jobs = Jobs
 guide-entry-sop-legal = Legal
 guide-entry-sop-standards = Standard Procedures
 # - Sub/Nested Directories
 guide-entry-sop-cargo = Cargo
 guide-entry-sop-command = Command
+guide-entry-sop-dignitary = Dignitary
 guide-entry-sop-engineering = Engineering
 guide-entry-sop-epistemics = Epistemics
 guide-entry-sop-medical = Medical
@@ -26,6 +27,7 @@ guide-entry-sop-violetalert = Violet Alert
 guide-entry-sop-whitealert = White Alert
 # - Standard Procedures
 guide-entry-sop-demoting = Dismissal/Demoting
+guide-entry-sop-evacuation = Early Evacuation
 guide-entry-sop-hiring = Hiring/Transfer
 guide-entry-sop-succession = Chain of Command
 # - Emergencies
@@ -46,8 +48,6 @@ guide-entry-sop-searches = Searches
 guide-entry-sop-cargotech = Cargo Tech
 guide-entry-sop-salvage = Salvage Specialist
 # - Command
-guide-entry-sop-ntr = Nanotrasen Rep.
-guide-entry-sop-bso = Blueshield Officer
 guide-entry-sop-captain = Captain
 guide-entry-sop-hop = Head of Personnel
 guide-entry-sop-hos = Head of Security
@@ -57,6 +57,10 @@ guide-entry-sop-cmo = Chief Medical Ofc.
 guide-entry-sop-ce = Chief Engineer
 # Logistics Officer changed by Delta-V (original: Quartermaster)
 guide-entry-sop-lo = Logistics Officer
+# - Dignitary
+guide-entry-sop-bso = Blueshield Officer
+guide-entry-sop-ntr = Nanotrasen Rep.
+guide-entry-sop-magistrate = Magistrate
 # - Engineering
 guide-entry-sop-atmostech = Atmos Tech
 guide-entry-sop-stationengineer = Station Engineer

--- a/Resources/Prototypes/_Goobstation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/sop.yml
@@ -13,6 +13,7 @@
   id: Alert Levels
   name: guide-entry-sop-alert-levels
   text: "/ServerInfo/Guidebook/SOP/AlertLevels/AlertLevelsSOP.xml"
+  priority: 0
   children:
   - GreenAlert SOP
   - BlueAlert SOP
@@ -29,6 +30,7 @@
   id: Emergencies SOP
   name: guide-entry-sop-emergencies
   text: "/ServerInfo/Guidebook/SOP/Emergencies/Emergencies.xml"
+  priority: 0
   children:
   - ConfirmedRevs SOP
   - ContainmentFail SOP
@@ -48,6 +50,7 @@
   - Alert Levels
   - Emergencies SOP
   - Demoting SOP
+  - EarlyEvacuation SOP
   - Hiring SOP
   - Succession
 
@@ -69,6 +72,7 @@
   children:
   - Cargo SOP
   - Command SOP
+  - Dignitary SOP
   - Engineering SOP
   - Epistemics SOP
   - Medical SOP
@@ -88,8 +92,6 @@
   name: guide-entry-sop-command
   text: "/ServerInfo/Guidebook/SOP/Jobs/Command/CommandSOP.xml"
   children:
-  - NanotrasenRep SOP
-  - BlueshieldOfficer SOP
   - Captain SOP
   - HeadOfPersonnel SOP
   - HeadOfSecurity SOP
@@ -97,6 +99,15 @@
   - ChiefMedicalOfficer SOP
   - ChiefEngineer SOP
   - LogisticsOfficer SOP # Changed for Delta-V Naming Scheme - Original: Quartermaster
+
+- type: guideEntry
+  id: Dignitary SOP
+  name: guide-entry-sop-dignitary
+  text: "/ServerInfo/Guidebook/SOP/Jobs/Dignitary/DignitarySOP.xml"
+  children:
+  - BlueshieldOfficer SOP
+  - NanotrasenRep SOP
+  - Magistrate SOP
 
 - type: guideEntry
   id: Engineering SOP
@@ -202,16 +213,25 @@
   id: Demoting SOP
   name: guide-entry-sop-demoting
   text: "/ServerInfo/Guidebook/SOP/StandardProcedures/FiringDemotion.xml"
+  priority: 10
+
+- type: guideEntry
+  id: EarlyEvacuation SOP
+  name: guide-entry-sop-evacuation
+  text: "/ServerInfo/Guidebook/SOP/StandardProcedures/EarlyEvacuationSOP.xml"
+  priority: 10
 
 - type: guideEntry
   id: Hiring SOP
   name: guide-entry-sop-hiring
   text: "/ServerInfo/Guidebook/SOP/StandardProcedures/HiringTransfers.xml"
+  priority: 10
 
 - type: guideEntry
   id: Succession
   name: guide-entry-sop-succession # Is named as "Chain of Command" in game.
   text: "/ServerInfo/Guidebook/SOP/StandardProcedures/CommandSuccession.xml"
+  priority: 10
 
 # Emergency SOP Entries
 - type: guideEntry
@@ -288,16 +308,6 @@
 
 # Command SOP Entries
 - type: guideEntry
-  id: NanotrasenRep SOP
-  name: guide-entry-sop-ntr
-  text: "/ServerInfo/Guidebook/SOP/Jobs/Command/NanotrasenRepSOP.xml"
-
-- type: guideEntry
-  id: BlueshieldOfficer SOP
-  name: guide-entry-sop-bso
-  text: "/ServerInfo/Guidebook/SOP/Jobs/Command/BlueshieldOfficerSOP.xml"
-
-- type: guideEntry
   id: Captain SOP
   name: guide-entry-sop-captain
   text: "/ServerInfo/Guidebook/SOP/Jobs/Command/CaptainSOP.xml"
@@ -331,6 +341,22 @@
   id: LogisticsOfficer SOP
   name: guide-entry-sop-lo
   text: "/ServerInfo/Guidebook/SOP/Jobs/Command/LogisticsOfficerSOP.xml"
+
+# Dignitary SOP Entries
+- type: guideEntry
+  id: NanotrasenRep SOP
+  name: guide-entry-sop-ntr
+  text: "/ServerInfo/Guidebook/SOP/Jobs/Dignitary/NanotrasenRepSOP.xml"
+
+- type: guideEntry
+  id: BlueshieldOfficer SOP
+  name: guide-entry-sop-bso
+  text: "/ServerInfo/Guidebook/SOP/Jobs/Dignitary/BlueshieldOfficerSOP.xml"
+
+- type: guideEntry
+  id: Magistrate SOP
+  name: guide-entry-sop-magistrate
+  text: "/ServerInfo/Guidebook/SOP/Jobs/Dignitary/MagistrateSOP.xml"
 
 # Engineering SOP Entries
 - type: guideEntry

--- a/Resources/ServerInfo/Guidebook/SOP/AlertLevels/AlertLevelsSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/AlertLevels/AlertLevelsSOP.xml
@@ -3,6 +3,12 @@
 The following alert levels are the publicly defined levels on this station and what they entail.
 Below are the listed pop-ups for each alert and the color associated with them.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
 There are individual entries for each alert level and what they entail for station personnel.
 
 <Table Columns="1">
@@ -126,7 +132,7 @@ The [color=#db7093]Gamma Alert[/color] is rare and often only used in extreme ca
 The [color=#cc74fc]Violet Alert[/color] is set for viral outbreaks when a zombie infection or other disease occurs.
 
 <Table Columns="1">
-  <ColorBox Color= "#ffffff">
+  <ColorBox Color="#ffffff">
     <Box HorizontalAlignment="Center" VerticalAlignment="Stretch" Margin="10">
       [bold][color=#000000][head=1]White Alert[/head][/color][/bold]
     </Box>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/CaptainSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/CaptainSOP.xml
@@ -15,7 +15,7 @@ This is the list of procedures, responsibilities, and duties of the [color=#1b67
 <Box>If neither are available on the current station, refer to the [bold]Chain of Command[/bold].</Box>
 
 5. Captain may keep Captain Space IDs in their room or give it to the appropriate members in the [bold]Chain of Command[/bold].
-<Box>The [color=#1b67a5][bold]Nanotrasen Representative[/bold][/color] and [color=#1b67a5][bold]Blueshield Officer[/bold][/color] are not permitted to carry these IDs.</Box>
+<Box>The [color=#1b67a5][bold]Nanotrasen Representative[/bold][/color], [color=#1b67a5][bold]Magistrate[/bold][/color], and [color=#1b67a5][bold]Blueshield Officer[/bold][/color] are not permitted to carry these IDs.</Box>
 
 6. The Captain is not to leave the Station unless given specific permission by Central Command.
 
@@ -26,9 +26,9 @@ This is the list of procedures, responsibilities, and duties of the [color=#1b67
 9. The Captain, despite being in charge of the Station, is not independent from NanoTrasen. Any attempts to disregard general company policy are to be considered an instant condition for contract termination.
 
 10. Firing a Head of Staff [bold]must[/bold] be done with reasonable justification. Refer to [bold]Dismissal/Demotion Policies[/bold].
-<Box>Firing Central Command VIPs ([color=#1b67a5][bold]Nanotrasen Representative[/bold][/color] and [color=#1b67a5][bold]Blueshield Officer[/bold][/color]) [bold]must[/bold] be done with authorization from Central Command.</Box>
+<Box>Firing Central Command VIPs ([color=#1b67a5][bold]Nanotrasen Representative[/bold][/color], [color=#1b67a5][bold]Magistrate[/bold][/color], and [color=#1b67a5][bold]Blueshield Officer[/bold][/color]) [bold]must[/bold] be done with authorization from Central Command.</Box>
 
-11. The Captain may not promote anyone to Central Command VIP Positions ([color=#1b67a5][bold]Nanotrasen Representative[/bold][/color] and [color=#1b67a5][bold]Blueshield Officer[/bold][/color]) without authorization from Central Command.
+11. The Captain may not promote anyone to Central Command VIP Positions ([color=#1b67a5][bold]Nanotrasen Representative[/bold][/color], [color=#1b67a5][bold]Magistrate[/bold][/color], and [color=#1b67a5][bold]Blueshield Officer[/bold][/color]) without authorization from Central Command.
 
 12. The Captain may carry their weaponry on them at all times.
 

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/CommandSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/CommandSOP.xml
@@ -8,12 +8,11 @@ Below are the list of guidelines [bold]all of Command should follow[/bold]:
 
 2. The Command Personnel may defend themselves and perform arrests as needed in self-defense, but may not try, place times, or perform any other Security activities except hand-off arrested personnel to Security.
 
-3. The Command Personnel may not, under any circumstances, promote station personnel to Central Command VIP Positions ([color=#1b67a5][bold]Nanotrasen Representative[/bold][/color] and [color=#1b67a5][bold]Blueshield Officer[/bold][/color]) without authorization from Central Command.
+3. The Command Personnel may not, under any circumstances, promote station personnel to Central Command VIP Positions ([color=#1b67a5][bold]Nanotrasen Representative[/bold][/color], [color=#1b67a5][bold]Magistrate[/bold][/color], and [color=#1b67a5][bold]Blueshield Officer[/bold][/color]) without authorization from Central Command.
 
 The following jobs have entries in this Department, the Chain of Command being linked at the top, the Central Command VIP being separated in terms of Chain of Command, the Captain being the top of Chain of Command, and all Heads of Staff on equal footing:
 - [textlink="Chain of Command" link="Succession"]
-- [textlink="Nanotrasen Representative" link="NanotrasenRep SOP"]
-- [textlink="Blueshield Officer" link="BlueshieldOfficer SOP"]
+- [textlink="Captain" link="Captain SOP"]
 - [textlink="Head of Personnel" link="HeadOfPersonnel SOP"]
 - [textlink="Head of Security" link="HeadOfSecurity SOP"]
 - [textlink="Mystagogue" link="Mystagogue SOP"]

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/HeadOfPersonnelSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/HeadOfPersonnelSOP.xml
@@ -12,7 +12,7 @@ This is the list of procedures, responsibilities, and duties of the [color=#1b67
 
 4. The Head of Personnel may not dismiss/demote any personnel without authorization from the relevant Head of Staff (exceptions apply: see Space Law and General SOP).
 
-5. The Head of Personnel may not promote anyone above Command. This includes positions such as Nanotrasen Representative, Blueshield Officer, and any other Central Command figure.
+5. The Head of Personnel may not promote anyone above Command. This includes positions such as Nanotrasen Representative, Magistrate, Blueshield Officer, and any other Central Command figure.
 
 6. The Head of Personnel may utilize paperwork for proceedings, but should expedite requests during major station emergencies. Emergency Access takes precedence over paper.
 

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/HeadOfSecuritySOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Command/HeadOfSecuritySOP.xml
@@ -2,6 +2,14 @@
 # Head of Security (HOS) SOP
 This is the list of procedures, responsibilities, and duties of the [color=#1b67a5][bold]Head of Security[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+The [color=#1b67a5][bold]Head of Security[/bold][/color] is permitted to carry their shift-start equipment, but should follow escalation procedures and refrain from using lethals.
+
 ## Green Alert
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers.
 
@@ -10,7 +18,8 @@ This is the list of procedures, responsibilities, and duties of the [color=#1b67
 
 3. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes.
 
-4. The Head of Security may not overrule a Captain/Nanotrasen Representative, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well.
+4. The Head of Security may not overrule a Captain/Magistrate, unless their decisions are blatantly breaking Space Law. In which case Central Command is to be contacted as well.
+<Box>This includes Nanotrasen Representative in cases of Standard Operating Procedure as well.</Box>
 
 5. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers.
 

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/BlueshieldOfficerSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/BlueshieldOfficerSOP.xml
@@ -1,0 +1,29 @@
+<Document>
+# Blueshield Officer (BSO) SOP
+This is the list of procedures, responsibilities, and duties of the [color=#1b67a5][bold]Blueshield Officer[/bold][/color] of this station.
+
+<ColorBox>
+  <Box HorizontalAlignment="Center" Margin="10">
+    The [color=#1b67a5][bold]Blueshield Officer[/bold][/color] should never be Captain nor Head of Staff.
+  </Box>
+</ColorBox>
+
+The [bold][color=#fcd12a]most important[/color][/bold] rule of the Blueshield Officer is to protect and maintain the lives of Command personnel on the station.
+<Box>Command personnel are personnel hired by Nanotrasen (confirmed personnel in command) and any Central Command officials (including BSO).</Box>
+
+1. The Blueshield Officer must listen to and follow orders of the NTR unless it would directly conflict with ensuring the safety of Command personnel or Central Command orders.
+
+2. The Blueshield Officer is to put the lives of Command over the lives of all others, including the Blueshield Officer. Their well-being is top priority.
+<Box>This includes first aid, revival, and ensuring they are safe and secure during emergencies.</Box>
+
+3. The Blueshield Officer is to protect the lives of Command, not follow their orders to a fault.
+
+4. The Blueshield Officer is not permitted to interfere with legal demotions or arrests. To do so would be a violation of their Central Command orders and Space Law.
+<Box>This primarily pertains to Command and Security work.</Box>
+
+5. The Blueshield Officer should not use lethal force unless there is a clear and present danger to Command and/or their lives.
+<Box>The Blueshield Officer must also be unable to non-lethally detain the assailant.</Box>
+
+6. The Blueshield Officer is permitted to use lethal force in certain emergencies; refer to Alert Levels.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/DignitarySOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/DignitarySOP.xml
@@ -1,0 +1,20 @@
+<Document>
+  # Dignitary Department Procedures
+  These are the list of SOPs that Dignitary Personnel should follow. These are, as stated before, [bold]not checklists[/bold] and should be treated as guidelines.
+
+  Below are the list of guidelines [bold]all of Dignitary should follow[/bold]:
+
+  1. Dignitaries [bold]are not[/bold] and [bold]should never be[/bold] Commmand Personnel. You are above Command.
+
+  2. Dignitaries respond to Central Command as needed, and should follow their orders over Command.
+
+  3. Dignitaries are to stick to their roles, and never become a personnel of the station; unless they are demoted by Central Command.
+
+  4. Dignitaries are upheld to expectations higher than Command Personnel and Security Personnel. You represent NanoTrasen afterall.
+
+  The following jobs have entries in this department:
+  - [textlink="Nanotrasen Representative" link="NanotrasenRep SOP"]
+  - [textlink="Magistrate" link="Magistrate SOP"]
+  - [textlink="Blueshield Officer" link="BlueshieldOfficer SOP"]
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/MagistrateSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/MagistrateSOP.xml
@@ -1,0 +1,40 @@
+<Document>
+  # Magistrate (MAG) SOP
+  This is the list of procedures, responsibilities, and duties of the [color=#1b67a5][bold]Magistrate[/bold][/color] of this station.
+
+  <ColorBox>
+    <Box HorizontalAlignment="Center" Margin="10">
+      The [color=#1b67a5][bold]Magistrate[/bold][/color] should never be Captain nor Head of Staff.
+    </Box>
+  </ColorBox>
+
+  The [bold][color=#fcd12a]most important[/color][/bold] rule of the Magistrate is to assist ensure Space Law is being followed.
+  <Box>Command personnel are personnel hired by Nanotrasen (confirmed personnel in command) and any Central Command officials (including MAG).</Box>
+
+  1. Magistrates are to ensure that Space Law is applied correctly. If it is not, they are to make it so.
+
+  2. Magistrates have the final say on whether or not Trials take place, and should ensure they should only occur for Capital Sentences.
+  <Box>Similarly, Magistrates are to ensure that Trials do not happen for Defendants that are self-evidently guilty, or those that do not want to participate in a trial (accepting Capital Punishment).</Box>
+
+  3. Magistrates can overrule anyone in all matters concerning Space Law. This does not extend to Emergency Response Teams, Central Command Officials or direct Central Command communications.
+
+  4. The Magistrate is permitted to carry their flash and a telescopic baton.
+
+  5. Magistrates are not above Space Law. Similarly, they cannot overrule Security on a sentence imposed against themselves. If a Magistrate attempts to do this, contact Central Command immediately.
+
+  6. In the absence of a Nanotrasen Representative, the Magistrate may elect to handle matters of Standard Operating Procedure. Otherwise, they must abide by Nanotrasen Representative's choices if there is one.
+
+  7. Magistrates may not impede the expedient functioning of Security for the sake of micromanaging every aspect it. They should only concern themselves with crimes that either have fuzzy evidence, or require careful deliberation of circumstances.
+
+  8. Magistrates are to contact Central Command immediately if their decisions are being ignored, provided said decision actually match up with Space Law and Standard Operating Procedure. Please see this guide for more information on how to write a good fax.
+
+  9. Magistrates are [bold]not[/bold] lawyers, and should leave the lawyering and talking down of sentences to said Lawyers.
+  <Box>If the Magistrate deems it necessary for a sentence to be adjusted, they may override Security.</Box>
+
+  10. Magistrates are to act as Judges in Trials unless they are connected/part of the crime, whether they be involved by witness or something else.
+
+  11. Magistrates are to ensure any trial taken place is speedy and thorough.
+
+  12. Magistrates are to ensure Executions are following standards, and override Captain in such cases for allowing them to take place, as stated in Guideline 3.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/NanotrasenRepSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/NanotrasenRepSOP.xml
@@ -1,0 +1,34 @@
+<Document>
+# Nanotrasen Representative (NTR) SOP
+This is the list of procedures, responsibilities, and duties of the [color=#1b67a5][bold]Nanotrasen Representative[/bold][/color] of this station.
+
+<ColorBox>
+  <Box HorizontalAlignment="Center" Margin="10">
+    The [color=#1b67a5][bold]Nanotrasen Representative[/bold][/color] should never be Captain nor Head of Staff.
+  </Box>
+</ColorBox>
+
+The [bold][color=#fcd12a]most important[/color][/bold] rule of the Nanotrasen Representative is to assist Command Personnel and ensure they are following SOP.
+<Box>Command personnel are personnel hired by Nanotrasen (confirmed personnel in command) and any Central Command officials (including NTR).</Box>
+
+## Resources
+1. The Nanotrasen Representative posesses a FAX machine to directly fax to Central Command (with notification to Central Command Officials).
+
+2. In the event of an emergency, the station is equipped with a minimum of one Red Phone which directly notifies Central Command.
+
+3. In the event of an emergency, the Nanotrasen Representative possesses a Central Command Encryption Key in their headset for direct communications with Central Command.
+
+## Rulings
+1. The Nanotrasen Representative is to ensure that every Department is following Standard Operating Procedure, including Command personnel.
+<Box>If a Department does not have a corresponding Head of Staff, NTR must ensure the Captain appoints an Acting Head of Staff and assist in such endeavors to guide them.</Box>
+
+2. The Nanotrasen Representative must attempt to resolve any [bold]major[/bold] breach of SOP before contacting Central Command. This is an imperative.
+<Box>Standard Operating Procedure must generally be followed with reasonable justifications when it is ignored.</Box>
+
+3. The Nanotrasen Representative is to ensure, along with Captain, Head of Security, and Warden, that Space Law is followed and being applied correctly.
+<Box>This does not permit NTR to override brig timers, punishments, or any other Security endeavor unless Central Command orders as such.</Box>
+
+4. The Nanotrasen Representative is not to use their direct connection to Central Command for leverage over other crew members.
+<Box>In addition, they may not threaten to fire anyone (nor contact Central Command to do so) unless a justification for demotion exists.</Box>
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/EpistemicsSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/EpistemicsSOP.xml
@@ -4,8 +4,17 @@ These are the list of SOPs that Epistemics Personnel should follow. These are, a
 
 <Box>For clarification, Golemancer can extend to any Epistemics personnel working on Robots.</Box>
 
-It is expected that [color=#cc74fc]Noviciate[/color], [color=#cc74fc]Acolyte[/color], and [color=#cc74fc]Mystic[/color] coincide in the same SOP guidelines.
-<Box>This is to consolidate the guidelines.</Box>
+It is expected that [color=#cc74fc]Noviciate[/color], [color=#cc74fc]Acolyte[/color], and [color=#cc74fc]Mystic[/color] coincide in the same SOP guidelines. This is to consolidate the guidelines.
+
+[color=#cc74fc]Chaplain[/color] and [color=#cc74fc]Mantis[/color] are Second in-commands to Mystagogue in the Epistemics department, with:
+- [color=#cc74fc]Chaplain[/color] overseeing the Oracle and Sacrifices.
+- [color=#cc74fc]Mantis[/color] assisting (alongside [color=#cc74fc]Cataloguer[/color]) with finding and keeping track of Psionic Users.
+
+<ColorBox>
+  <Box>
+    Be sure to read over the guidebook entires of the the Epistemics jobs and to also follow the Sacrifices Rulings.
+  </Box>
+</ColorBox>
 
 The following jobs have entries in this Department, the [color=#1b67a5][bold]Mystagogue[/bold][/color] being the Head of Staff:
 - [textlink="Mystagogue" link="Mystagogue SOP"]

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/GolemancerSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/GolemancerSOP.xml
@@ -3,6 +3,12 @@
 This is the list of procedures, responsibilities, and duties of the [color=#cc74fc]Golemancer[/color] of this station.
 <Box>For clarification, 'Researcher' and 'Golemancer' are both referred to as 'Researcher' in this SOP.</Box>
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
 ## Green Alert
 1. The Researcher is not permitted to construct any Combat Mechs without express permission from the Captain and/or Head of Security.
 <Box>The [color=#1b67a5][bold]Research Director[/bold][/color] is placed under these same restrictions.</Box>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/MantisSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/MantisSOP.xml
@@ -17,4 +17,8 @@ The Mantis is a role that works with [color=#cc74fc]Cataloguer[/color] and [colo
 
 6. During [bold][color=#ffffff]White Alert[/color][/bold] the Mantis should assist the [color=#1b67a5][bold]Mystagogue[/bold][/color] with hunting down the Psionic Users and only answers to the [color=#1b67a5][bold]Mystagogue[/bold][/color] and/or [color=#1b67a5][bold]Captain[/bold][/color].
 
+7. Mantis is permitted mindbreaking chemicals, such as (and including):
+- Crystobiolin
+- Space Drugs (anything related to Psionics)
+
 </Document>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/ResearcherSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/ResearcherSOP.xml
@@ -4,6 +4,12 @@ This is the list of procedures, responsibilities, and duties of the [color=#cc74
 
 For clarification, 'Researcher' is used as a catch-all-phrase for Noviciate, Acolyte, and Mystic.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
 ## Green Alert
 1. Researchers are not permitted to bring grenades, harmful chemicals, nor Toxin bombs outside of the Epistemics Department.
 <Box>[bullet/]Exceptions for the Toxin bombs if being handed over to the Cargo Department for Salvaging operations.</Box>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/SacrificesSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Epistemics/SacrificesSOP.xml
@@ -2,13 +2,19 @@
 # Sacrifices SOP
 Sacrifice is a procedure that can only be performed by the [color=#cc74fc]Chaplain[/color] or [color=#1b67a5][bold]Mystagogue[/bold][/color].
 
-1. Sacrifices must be performed on [bold][color=#ffffff]White Alert[/color][/bold] to reduce the Glimmer Levels to a sustainable level.
+1. Sacrifices can be performed on [bold][color=#ffffff]White Alert[/color][/bold] to reduce the Glimmer Levels to a sustainable level.
 
-2. Sacrifices should only be performed on Psionic Users that are abusing their powers; unless it is necessary to reduce the Glimmer Levels immediately.
+2. Sacrifices should [bold]only be performed[/bold] on Psionic Users that are abusing their powers; unless it is necessary to reduce the Glimmer Levels immediately.
+<Box>[bold]Mindbreaking[/bold] should be prioritized for users that are [bold][italic]not actively/maliciously[/italic][/bold] misusing their psionic powers.</Box>
 
 3. Sacrifices should be performed on Criminal Psionic Users over other Psionic Users.
+<Box>Sacrifices are permitted on those that are permanently brigged and misusing their powers.</Box>
 
 4. Sacrifices should not be performed when it isn't [bold][color=#ffffff]White Alert[/color][/bold] unless it is consentual.
 <Box>The only exception to this rule is if it is necessary due to an immediate and quickly rising Glimmer Level.</Box>
+
+5. Mindbreaking Chemicals are permitted to Epistemics when dealing with White Alert and needing to mindbreak instead of sacrifice.
+
+6. Any sacrificed personnel should be converted into golems or borgified. This is a requirement.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/JobsSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/JobsSOP.xml
@@ -9,6 +9,7 @@ Attached below this are several different categories for Job-Specific Standard O
 The following folders are listed underneath this folder:
 - [textlink="Cargo Department" link="Cargo SOP"]
 - [textlink="Command Department" link="Command SOP"]
+- [textlink="Dignitary Department" link="Dignitary SOP"]
 - [textlink="Engineering Department" link="Engineering SOP"]
 - [textlink="Epistemics Department" link="Epistemics SOP"]
 - [textlink="Medical Department" link="Medical SOP"]

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/CorpsmanSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/CorpsmanSOP.xml
@@ -2,6 +2,8 @@
 # Corpsman SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Corpsman[/bold][/color] of this station.
 
+[color=#ba292c][bold]Corpsman[/bold][/color]s are permitted to carry their shift-start pistols, but should follow escalation laws and leave them holstered on Green Alert.
+
 Corpsman are held to the same guidelines and responsibilities as [textlink="Paramedic" link="DoctorIntern SOP"]; with exceptions that they are to cater to Security Personnel and Prisoners over regular station personnel.
 
 1. Corpsman are to respond to demands from [color=#ba292c][bold]Warden[/bold][/color] for Security Treatment with immediate priority.
@@ -10,7 +12,8 @@ Corpsman are held to the same guidelines and responsibilities as [textlink="Para
 
 3. Corpsman are to follow the same guidelines as [textlink="Security Officers" link="OfficerCadet SOP"] for [color=#388c34]Green Alert[/color] and [color=#1b67a5]Blue Alert[/color].
 
-4. Corpsman are not permitted to carry lethal weapons except on [color=#ba292c]Red Alert[/color] and higher.
+4. Corpsman are not permitted to unholster lethal weapons except on [color=#ba292c]Blue Alert[/color] and higher, following escalation procedures and only for self-defense.
+<Box>If necessary, the Corpsman may use lethal weaponry on clear hostiles, but must take responsibility as a Security Officer would.</Box>
 
 5. Corpsman are to prioritize treatment of Prisoners over regular Medical Personnel.
 

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/DetectiveSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/DetectiveSOP.xml
@@ -2,6 +2,14 @@
 # Detective SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Detective[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+The [color=#ba292c][bold]Detective[/bold][/color] is permitted to carry their shift-start equipment, but should follow escalation laws and leave them holstered on Green Alert.
+
 ## Green Alert
 1. The Detective is permitted to assist Security Officers with all Patrol Duties. This includes stops, searches, and arrests as per the current Alert Code.
 <Box>They should, however, prioritize investigations and the collection of forensic evidence.</Box>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/OfficerCadetSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/OfficerCadetSOP.xml
@@ -2,6 +2,14 @@
 # Officer/Cadet SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Security Officer[/bold][/color] and [color=#ba292c][bold]Security Cadet[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+[color=#ba292c][bold]Security Officer[/bold][/color]s are permitted to carry their shift-start weapons, but should follow escalation laws and leave them holstered on Green Alert.
+
 ## Green Alert
 1. Security Officers are required to state the reasons behind an arrest before any further action is taken.
 <Box>Exception is made if the suspect refuses to stop.</Box>
@@ -16,6 +24,7 @@ This is the list of procedures, responsibilities, and duties of the [color=#ba29
 <Box>Exceptions apply when a hostile suspect is within an inaccessible area.</Box>
 
 6. Security officers are not permitted to have weapons drawn during regular patrols.
+<Box>Refer to escalation rules for necessary use of shift-start weaponry.</Box>
 
 7. Security officers are permitted to conduct searches, provided there is reasonable evidence/suspicion that the person in question has committed a crime.
 <Box>Any further searches require a warrant from the Captain and/or Head of Security.</Box>

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/PrisonGuardSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/PrisonGuardSOP.xml
@@ -2,6 +2,8 @@
 # Prison Guard SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Prison Guard[/bold][/color] of this station.
 
+[color=#ba292c][bold]Prison Guard[/bold][/color]s are permitted to carry their shift-start weaponry, but should follow escalation procedures and keep them holstered, following the Security Officer guidelines.
+
 Prison Guards should follow the same rules as [textlink="Security Officers" link="OfficerCadet SOP"] while remaining in the Security Department much like the [textlink="Warden" link="Warden SOP"] unless transporting Prisoners or taking a break.
 
 1. Prison Guards are not permitted to leave the Security Department unless they are transporting Prisoners.

--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/WardenSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Security/WardenSOP.xml
@@ -2,6 +2,14 @@
 # Warden SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Warden[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+The [color=#ba292c][bold]Warden[/bold][/color] is permitted to carry their shift-start equipment, but should follow escalation procedures and refrain from using lethals.
+
 ## Green Alert
 1. The Warden is obligated to remain in the Security Department at all times except to assist in transportation of prisoners.
 <Box>The Warden must maintain control over the Armory as well, with only exceptions being allowed for Captain and Head of Security.</Box>

--- a/Resources/ServerInfo/Guidebook/SOP/Legal/ExecutionSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Legal/ExecutionSOP.xml
@@ -17,8 +17,8 @@ These are the procedures that [bold]must[/bold] be followed by Security and Comm
 
 7. It is advised, but not required, to have medical personnel in attendance to verify death.
 
-8. Authorization must be given by the Nanotrasen Representative. If one is not present, dead, or missing, the Captain may authorize an execution in their stead.
-<Box>Should the Nanotrasen Representative and Captain be unable to provide authorization, it must come from Central Command. Without authorization, executions are murder.</Box>
+8. Authorization must be given by the Magistrate. If one is not present, dead, or missing, the Captain may authorize an execution in their stead.
+<Box>Should the Magistrate and Captain be unable to provide authorization, it must come from Central Command. Without authorization, executions are murder.</Box>
 
 9. Though not obligatory, it is recommended that all executed prisoners be considered for cyborgification post-execution.
 

--- a/Resources/ServerInfo/Guidebook/SOP/SoP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/SoP.xml
@@ -31,6 +31,7 @@ The following links are for general knowledge of the station.
 The following links are for general department SOPs. These will guide you to the folder entry.
 - [textlink="Cargo Department" link="Cargo SOP"]
 - [textlink="Command Department" link="Command SOP"]
+- [textlink="Dignitary Department" link="Dignitary SOP"]
 - [textlink="Engineering Department" link="Engineering SOP"]
 - [textlink="Epistemics Department" link="Epistemics SOP"]
 - [textlink="Medical Department" link="Medical SOP"]

--- a/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/CommandSuccession.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/CommandSuccession.xml
@@ -2,13 +2,13 @@
 # Chain of Command
 This is the ideal list for passing down the Captain role in command. There are several factors to take into respect here, but this boils down to a simple list.
 
-[bullet/][color=#1b67a5]Blueshield Officer[/color] (BSO) and [color=#1b67a5]Nanotrasen Representative[/color] (NTR) should never hold a position of command on this station.
+1. [color=#1b67a5]Blueshield Officer[/color] (BSO), [color=#1b67a5]Nanotrasen Representative[/color] (NTR), and [color=#1b67a5]Magistrate[/color] (MAG) should never hold a position of command on this station.
 
-[bullet/]This list can be deviated from for special circumstances, with the vote resting on Command to do so.
+2. This list can be deviated from for special circumstances, with the vote resting on Command to do so.
 
-[bullet/][color=#1b67a5]Nanotrasen Representative[/color], if one is present, should assist in this process and guide the new Captain.
+3. [color=#1b67a5]Nanotrasen Representative[/color], if one is present, should assist in this process and guide the new Captain.
 
-[bullet/]When choosing the succeeding Captain, they should be marked on their ID as [color=#1b67a5]Acting Captain[/color] (following the same promotion procedures).
+4. When choosing the succeeding Captain, they should be marked on their ID as [color=#1b67a5]Acting Captain[/color] (following the same promotion procedures).
 
 <Box>~</Box>
 <Box>[bold][color=#1b67a5][head=1]Command Succession[/head][/color][/bold]</Box>
@@ -29,12 +29,12 @@ The succession list is shown from [bold]top to bottom[/bold] and should be follo
 
 If it is deemed necessary, or by wish of the Head of Staff that is being chosen, the next person in the succession may be skipped.
 
-[bullet/]For choices where the Head of Staff is deemed necessary to skip by others, it should be put to a vote by successors (barring Security Officers).
+1. For choices where the Head of Staff is deemed necessary to skip by others, it should be put to a vote by successors (barring Security Officers).
 
-[bullet/]For choices where the Head of Staff chooses to not accept the title, they should have a valid reason for doing so and justify it if necessary.
+2. For choices where the Head of Staff chooses to not accept the title, they should have a valid reason for doing so and justify it if necessary.
 
 ## Choosing Security Officers
-When choosing Security Officers for Command Succession, it should be put to a vote by all those included if there is no [color=#1b67a5]Nanotrasen Representative[/color].
+When choosing Security Officers for Command Succession, it should be put to a vote by all those included if there is no [color=#1b67a5]Nanotrasen Representative[/color] or [color=#1b67a5][bold]Magistrate[/bold][/color].
 
 When voting, it should be held as fast as possible. If a tie happens while voting, seniority should prevail.
 

--- a/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/EarlyEvacuationSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/EarlyEvacuationSOP.xml
@@ -1,0 +1,20 @@
+<Document>
+  # Early Evaucation Procedures
+  These are the guidelines that should be followed as Command and Security when initiating early-launch procedures.
+
+  1. Under [bold]no circumstances[/bold] should the evacuation shuttle be early launched when there is no [bold][italic]immediate[/italic][/bold] threat to the evacuation shuttle.
+
+  2. The Command should wait as [bold]long as possible[/bold] before initiating early launch procedures.
+
+  3. No member of Command or Station (with access to Command) should initiate early evacuation procedures until every participating member is ready.
+  <Box>To clarify, there should not be individual inputs until everyone is ready, to prevent potential hostiles and/or thieves from taking IDs and starting it with adequate permissions.</Box>
+
+  4. Early Evacuation should be called when a loosed material or threat were to harm the evacuation shuttle imminently. The following would be examples: Teslas, Singularities, Hostile Enemy Ships.
+
+  5. Early Evacuation should be called when there are hostiles on the evacuation shuttle that are threatening the lives of the station personnel and bridge personnel.
+  <Box>Said hostiles must be, in reasonable suspicion, unable to be taken down without significant loss of life to everyone currently on-board.</Box>
+
+  6. Early Evacuation must be called when there is a Violet Alert to prevent potential specimens from arriving aboard the shuttle.
+  <Box>If it is possible to defend the shuttle, this should be prioritized.</Box>
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/FiringDemotion.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/FiringDemotion.xml
@@ -3,19 +3,19 @@
 These are the policies/procedures that should be followed when dismissing or demoting personnel from a position.
 
 1. In the event of a full dismissal from a position, the personnel should have their ID marked as "Terminated" and set to an Assistant in terms of accesses (only Maintenance).
-<Box>[bullet/]Extra access should not be permitted except for special cases with approval from Captain or a relevant Head of Staff (when giving access to a Department).</Box>
-<Box>[bullet/]If dismissed by Central Command orders, authorization for extra access should be given by Central Command.</Box>
+<Box>Extra access should not be permitted except for special cases with approval from Captain or a relevant Head of Staff (when giving access to a Department).</Box>
+<Box>If dismissed by Central Command orders, authorization for extra access should be given by Central Command.</Box>
 
 2. In the event of a demotion, the relevant Head of Staff must choose whether to demote them to a lower rank in the Department or have them transferred to a Service position (with HoP approval).
-<Box>[bullet/]It is recommended that the personnel, when demoted out of a Department, be granted access to a Service job of their choice, or demoted to an Assistant (and marked as such).</Box>
+<Box>It is recommended that the personnel, when demoted out of a Department, be granted access to a Service job of their choice, or demoted to an Assistant (and marked as such).</Box>
 
 3. Dismissals and Demotions should not be performed without authorization from the relevant Head of Staff or Captain; unless specified by orders from Central Command or immense violations of Space Law.
-<Box>[bullet/]In such cases of immense violations of Space Law, the perpetrator must have committed serious crimes and/or actively be punished with Perma Brig.</Box>
+<Box>In such cases of immense violations of Space Law, the perpetrator must have committed serious crimes and/or actively be punished with Perma Brig.</Box>
 
 4. Personnel that are dismissed or demoted by a Head of Staff or Authoritative Personnel must report to Head of Personnel for dismissal/demotion. Failure to do so will result in legal authority to detain with force.
 
 5. Personnel that are dismissed or demoted are considered trespassing in areas they would no longer have access. Any materials kept from areas are considered contraband (if listed as such) and should be turned in.
-<Box>[bullet/]Personnel are allowed to keep items not listed as contraband, but should not inhibit the Department.</Box>
+<Box>Personnel are allowed to keep items not listed as contraband, but should not inhibit the Department.</Box>
 
 ## Causes for Dismissal or Demotion
 1. Any [bold]major[/bold] breach of Standard Operating Procedure without propable cause.
@@ -25,19 +25,19 @@ These are the policies/procedures that should be followed when dismissing or dem
 3. Unreasonable/Major Incompetence in current position.
 
 4. Refusal to follow legal/relevant orders from respective Head of Staff or Captain.
-<Box>[bullet/]Legality and relevance of the order must be decided by Captain or Head of Personnel</Box>
+<Box>Legality and relevance of the order must be decided by Captain or Head of Personnel</Box>
 
 5. Creation of an abusive, dangerous, and/or unsafe work environment. Written approval for dangerous creations must be approved by respective Head of Staff or Captain.
-<Box>[bullet/]Abusive environments include berating, insulting, belittling, or otherwise treating coworkers like dirt.</Box>
+<Box>Abusive environments include berating, insulting, belittling, or otherwise treating coworkers like dirt.</Box>
 
 ## Vote of No Confidence
 A [italic]Vote of No Confidence[/italic] is a method for crew members to arrange for the removal of a Command Personnel (barring Central Command personnel). It must be justified with reasoning found below.
 
 1. Voting must be verified by a third party who can tally the votes and verify the validity (this should usually be Central Command personnel, such as NTR).
-<Box>[bullet/]The third party must be on-station. The third party should be the Captain if they are not the target in question.</Box>
+<Box>The third party must be on-station. The third party should be the Captain if they are not the target in question.</Box>
 
 2. If the third party dismisses the vote, for any reason, the individual must be treated as if it had not happened. They maintain their authority.
-<Box>[bullet/]In cases of a tie or understaffed environments, the third party may participate in the vote.</Box>
+<Box>In cases of a tie or understaffed environments, the third party may participate in the vote.</Box>
 
 3. Votes by Departmental crew against the Head of Staff must pass with majority in the Department (2/3rd majority in favor).
 

--- a/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/HiringTransfers.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/StandardProcedures/HiringTransfers.xml
@@ -7,7 +7,7 @@ These are the policies/procedures that should be followed when hiring or transfe
 
 2. Promotions to Acting Head of Staff of a Department requires approval from Captain or Acting Captain. Central Comman may be contacted if so desired.
 
-3. Positions above Command (Nanotrasen Representative and Blueshield Officer) cannot be promoted to without consent/authorization from Central Command.
+3. Positions above Command (Nanotrasen Representative, Magistrate, and Blueshield Officer) cannot be promoted to without consent/authorization from Central Command.
 
 4. All new hires to Security and/or Command positions should be mindshielded, checked for implanted materials and/or contraband, and checked for suspicious communication devices.
 


### PR DESCRIPTION
# Description
This is a remake of PR #30.

This adds several important details to the SOP, tweaks some of the already created entries, prepares and adds Magistrate SOP rulings for the future preparation of Magistrate being added, changes Epistemics entries to account for Sacrifices and Mantis necessities, and more (shown in the TODO section).

---

# TODO
There is a lot to breakdown here, so I'm going to separate this into categories for easier attention to detail.

### Security/Legal Changes
- [x] Add Alert Clarification (make it clear which alerts pertain to what).
- [x] Change Nanotrasen Representative (NTR) in Executions to Magistrate (they deal with space law, not NTR).
- [x] Specify that Security that (can) spawn with lethal weaponry should follow Green Alert procedures and keep it holstered (like Corpsman).
- [x] Specify that any shift-start weaponry in Security may be kept (just redundancy for last one).

### (NEW) Dignitary Entry and Entries/Changes
- [x] Create the Dignitary Department (in Guidebook only for now).
- [x] Move Nanotrasen Representative (NTR) and Blueshield Officer (BSO) into the Dignitary Department.
- [x] Add Magistrate (MAG) and format Dignitary Department for it.
- [x] Clarify Central Command VIP (Dignitary) rules in the SOP.
- [x] Make sure that all relations to Central Command VIPs are tied to NTR, BSO, and MAG (like making sure they are referenced in hiring/demoting policies).
- [x] Clarify that Dignitaries are above Command and held to even higher responsibilities.

### SOP Additions/Changes
- [x] Add Early Evacuation procedures.
- [x] Tweak the children order in Standard Procedures.
- [x] Fix naming scheme for Alert Levels and Emergencies now that priority is specified.

### Epistemics Changes
- [x] Rework Sacrifices wording to prefer Mindbreak and only Sacrifice malicious Psionics Users
- [x] Clarify that Mantis and Chaplain operate as Second-In-Commands for Mystagogue.
- [x] Clarify that Mantis is permitted to carry Mindbreaking chemicals and Space Drugs.
- [x] Reformat the Epistemics SOP to not be so booty.
- [x] Add Alert Levels differentiation to the Epistemics Entries (that reference them) as well.

---

# Media
This section is split into several different screenshot sections to make it easier to review.

<details><summary><h3>SOP Order Changes and Alert Level Changes</h3></summary>
<p>

![image](https://github.com/user-attachments/assets/39f4c5c6-86fb-42f7-bc8e-2cd1517c1f5a)
![image](https://github.com/user-attachments/assets/fe396d61-18d6-4919-8c80-80ec5bd07870)
![image](https://github.com/user-attachments/assets/95dfc019-f53c-4263-a47c-bd99bb258a7e)

</p>
</details>

<details><summary><h3>Security/Legal Changes</h3></summary>
<p>

![image](https://github.com/user-attachments/assets/46fa2aa4-37be-42be-a426-0154329d9ae2)
![image](https://github.com/user-attachments/assets/d22a9ae4-b142-4096-a468-330cbc696777)

</p>
</details>

<details><summary><h3>Dignitary Changes</h3></summary>
<p>

![image](https://github.com/user-attachments/assets/9694d0c8-b750-41f4-b0a7-5b891e71fc5a)
![image](https://github.com/user-attachments/assets/3c4b84a0-2c00-4a1e-a633-b27a046f89c4)

</p>
</details>

<details><summary><h3>Epistemics Changes</h3></summary>
<p>

![image](https://github.com/user-attachments/assets/24e26825-af45-4ac8-829b-aa2c866f7263)
![image](https://github.com/user-attachments/assets/6885d867-a4e2-4873-9d6b-9c562f5688e4)
![image](https://github.com/user-attachments/assets/6b3bfd81-f9af-4cb7-8ed0-302ec18b329d)
![image](https://github.com/user-attachments/assets/bb20fff9-bb7b-4fb5-9575-f1cf5cf7636a)

</p>
</details>

---

# Changelog

:cl:
- add: Added Magistrate SOP and Early Evacuation Procedures SOP entries.
- tweak: Moved Nanotrasen Representative, Blueshield Officer, and Magistrate into Dignitary Department.
- tweak: Clarified that Magistrate overrules Space Law of everyone else and oversees Executions.
- tweak: Clarified Alert Level relations to jobs/Alert Levels entry and how they relate to Green/Blue/Red for Security and Epistemics. (Check Alert Levels.)
- tweak: Clarified that Mantis and Chaplain are Second-In-Command for Mystagogue.
- fix: Clarified that Security Personnel are allowed to carry their Shift-Start (Loadout) Weapons, but have to abide by Alert Levels.
- fix: Fixed priority of children guide entries in Standard Procedures.
- remove: Removed bullet points from the Demotion Procedures (they looked ugly).
