### PR TITLE
Mantis Violence Update

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -18,6 +18,10 @@
         - !type:CharacterTraitRequirement
           traits:
             - AnomalousPositronics
+        - !type:CharacterTraitRequirement
+          inverted: true    
+          traits:
+            - Pacifist
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"
   supervisors: job-supervisors-rd


### PR DESCRIPTION
I Hate Pacifist Mantises

# Description 

This PR literally just removes the ability of the Mantis to be a pacifist. He's given a gun and a knife for a reason, his job is a violent one, makes no sense that he should be able to be a pacifist.

---

# TODO

- [x] Disable pacifism for the Mantis

---

# Changelog

:cl: ShirouAjisai
- tweak: Mantis can no longer be a pacifist