### PR TITLE
Shadowkin Nerf.... 

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/DarkSwapSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/DarkSwapSystem.cs
@@ -1,60 +1,60 @@
-using Content.Shared.Abilities.Psionics;
-using Content.Shared.Actions.Events;
-using Content.Shared.Shadowkin;
-using Content.Shared.Physics;
-using Content.Shared.Popups;
-using Content.Shared.Maps;
-using Robust.Server.GameObjects;
+# using Content.Shared.Abilities.Psionics;
+# using Content.Shared.Actions.Events;
+# using Content.Shared.Shadowkin;
+# using Content.Shared.Physics;
+# using Content.Shared.Popups;
+# using Content.Shared.Maps;
+# using Robust.Server.GameObjects;
 
-namespace Content.Server.Abilities.Psionics
-{
-    public sealed class DarkSwapSystem : EntitySystem
-    {
-        [Dependency] private readonly SharedPsionicAbilitiesSystem _psionics = default!;
-        [Dependency] private readonly SharedPopupSystem _popup = default!;
-        [Dependency] private readonly PhysicsSystem _physics = default!;
+# namespace Content.Server.Abilities.Psionics
+# {
+#     public sealed class DarkSwapSystem : EntitySystem
+#     {
+#         [Dependency] private readonly SharedPsionicAbilitiesSystem _psionics = default!;
+#         [Dependency] private readonly SharedPopupSystem _popup = default!;
+#         [Dependency] private readonly PhysicsSystem _physics = default!;
 
-        public override void Initialize()
-        {
-            base.Initialize();
-            SubscribeLocalEvent<DarkSwapActionEvent>(OnPowerUsed);
-        }
+#         public override void Initialize()
+#         {
+#             base.Initialize();
+#             SubscribeLocalEvent<DarkSwapActionEvent>(OnPowerUsed);
+#         }
+# 
+#         private void OnPowerUsed(DarkSwapActionEvent args)
+#         {
+#             if (TryComp<EtherealComponent>(args.Performer, out var ethereal))
+#             {
+#                 var tileref = Transform(args.Performer).Coordinates.GetTileRef();
+#                 if (tileref != null
+#                 && _physics.GetEntitiesIntersectingBody(args.Performer, (int) CollisionGroup.Impassable).Count > 0)
+#                 {
+#                     _popup.PopupEntity(Loc.GetString("revenant-in-solid"), args.Performer, args.Performer);
+#                     return;
+#                 }
 
-        private void OnPowerUsed(DarkSwapActionEvent args)
-        {
-            if (TryComp<EtherealComponent>(args.Performer, out var ethereal))
-            {
-                var tileref = Transform(args.Performer).Coordinates.GetTileRef();
-                if (tileref != null
-                && _physics.GetEntitiesIntersectingBody(args.Performer, (int) CollisionGroup.Impassable).Count > 0)
-                {
-                    _popup.PopupEntity(Loc.GetString("revenant-in-solid"), args.Performer, args.Performer);
-                    return;
-                }
+#                 if (_psionics.OnAttemptPowerUse(args.Performer, "DarkSwap"))
+#                 {
+#                     SpawnAtPosition("ShadowkinShadow", Transform(args.Performer).Coordinates);
+#                     SpawnAtPosition("EffectFlashShadowkinDarkSwapOff", Transform(args.Performer).Coordinates);
+#                     RemComp(args.Performer, ethereal);
+#                     args.Handled = true;
+#                 }
+#             }
+#             else if (_psionics.OnAttemptPowerUse(args.Performer, "DarkSwap", args.ManaCost))
+#             {
+#                 var newethereal = EnsureComp<EtherealComponent>(args.Performer);
+#                 newethereal.Darken = true;
 
-                if (_psionics.OnAttemptPowerUse(args.Performer, "DarkSwap"))
-                {
-                    SpawnAtPosition("ShadowkinShadow", Transform(args.Performer).Coordinates);
-                    SpawnAtPosition("EffectFlashShadowkinDarkSwapOff", Transform(args.Performer).Coordinates);
-                    RemComp(args.Performer, ethereal);
-                    args.Handled = true;
-                }
-            }
-            else if (_psionics.OnAttemptPowerUse(args.Performer, "DarkSwap", args.ManaCost))
-            {
-                var newethereal = EnsureComp<EtherealComponent>(args.Performer);
-                newethereal.Darken = true;
+#                 SpawnAtPosition("ShadowkinShadow", Transform(args.Performer).Coordinates);
+#                 SpawnAtPosition("EffectFlashShadowkinDarkSwapOn", Transform(args.Performer).Coordinates);
 
-                SpawnAtPosition("ShadowkinShadow", Transform(args.Performer).Coordinates);
-                SpawnAtPosition("EffectFlashShadowkinDarkSwapOn", Transform(args.Performer).Coordinates);
+#                 args.Handled = true;
+#             }
 
-                args.Handled = true;
-            }
-
-            if (args.Handled)
-                _psionics.LogPowerUsed(args.Performer, "DarkSwap");
-        }
-    }
-}
+#             if (args.Handled)
+#                 _psionics.LogPowerUsed(args.Performer, "DarkSwap");
+#         }
+#     }
+# }
 
 

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -365,12 +365,12 @@
     Slash: 1.3
     Piercing: 1.2
     Asphyxiation: 0
-    Cold: 1.2
+    Cold: 0.8
     Heat: 1.2
     Cellular: 0.50
-    Bloodloss: 1.45
+    Bloodloss: 1.35
     Shock: 1.35
-    Radiation: 1.5
+    Radiation: 1.45
 
 - type: damageModifierSet
   id: DermalArmor

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -361,16 +361,16 @@
 - type: damageModifierSet
   id: Shadowkin
   coefficients:
-    Blunt: 0.95
-    Slash: 1.2
-    Piercing: 1.1
+    Blunt: 1.2
+    Slash: 1.3
+    Piercing: 1.2
     Asphyxiation: 0
-    Cold: 0.75
+    Cold: 1.2
     Heat: 1.2
-    Cellular: 0.25
-    Bloodloss: 1.35
-    Shock: 1.25
-    Radiation: 1.3
+    Cellular: 0.50
+    Bloodloss: 1.45
+    Shock: 1.35
+    Radiation: 1.5
 
 - type: damageModifierSet
   id: DermalArmor

--- a/Resources/Prototypes/Species/shadowkin.yml
+++ b/Resources/Prototypes/Species/shadowkin.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Shadowkin
   name: species-name-shadowkin
-  roundStart: false
+  roundStart: true
   prototype: MobShadowkin
   sprites: MobShadowkinSprites
   defaultSkinTone: "#FFFFFF"


### PR DESCRIPTION
# Description

Honestly... much needed until they can get a proper rework from the original creators. This PR nerfs them a shit ton (no more teleporting away when you're in danger, smh) to make them more in line with the other species so they aren't powergamer central. Additionally, brings them more in-line with the traditional SS13 shadowkin. Shadowkins should no longer get darkswap and such, in fact I've commented out the entire ability until it too can get a rework. 

---

# TODO

- [x] Commented out DarkSwap for shadowkin & for everynoe else
- [x] Made shadowkins much more easy to damage
- [x]  Brought shadowkin much more in line with their SS13 counterparts
- [ ] Fixed shadowkin lore, making the guidebook entry more interesting
- [x] Shadowkin can be chosen as a player species roundstart
- [ ] Make DarkSwap unable to interact with the world as a whole
- [ ] Give DarkSwap a longer cooldown
- [ ] Make DarkSwap unable to be used if stunned
- [ ] Adjust DarkSwap glimmer production
- [ ] Shadowkin do not have black eyes by default
- [ ] Shadowkin have the black eyes trait listed (Waveform Misalignment equivalent)
- [ ] Shadowkin are affected by glimmer (all negative affects from high glimmer are doubled)

---

# Changelog

:cl:
- add: Shadowkins can now be roundstart species again
- tweak: Shadowkins are now more easy to damage
- tweak Shadowkins are much more like their SS13 counterparters
- remove: Removed DarkSwap as an ability as a whole.