### PR TITLE
Add Revolutionaries Back & Adjust Weighting Scale

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -165,7 +165,7 @@
     - revolutionaries
   name: rev-title
   description: rev-description
-  showInVote: false
+  showInVote: true # Goobstation - LET IT LIVE
   rules:
     - Revolutionary
     - SubGamemodesRule

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,10 +1,11 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Survival: 0.34
+    Survival: 0.16
     Nukeops: 0.14
-    Zombie: 0.03
+    Zombie: 0.07
     Traitor: 0.34
     BloodCult: 0.15
     #Pirates: 0.15 #ahoy me bucko
+    Revolutionary: 0.14 # ADD THEM BACK
 


### PR DESCRIPTION
# Description
This adds Revolutionaries back (because it's MRP and, like, revolutionaries are insanely good for roleplay) and halves the weighting for Survival (which is boring as hell because of other weighting). This weighting goes to Revolutionaries and increases zombies a slight bit, nothing exponential.

---

# Changelog
:cl:
- add: Added Revolutionaries back to Secret Gamemode!
- add: Added Revolutionaries back to gamemode voting.
- tweak: Adjusted Secret gamemode weighting schema.
