### PR TITLE
Re-Enable Kill Objective, Reduce Teach A Lesson Weight

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -31,8 +31,8 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupKill
   weights:
-    # KillRandomPersonObjective: 1 # DeltaV Replaced for Teach Lesson
-    TeachLessonRandomPersonObjective: 1
+    KillRandomPersonObjective: 1 # DeltaV Replaced for Teach Lesson # Goobstation - re-enabled Kill Person objective
+    TeachLessonRandomPersonObjective: 0.1 # Goobstation - reduced Teach Lesson weight
     KillRandomHeadObjective: 0.25
 
 - type: weightedRandom


### PR DESCRIPTION
# Description

Re-enables the kill objective which was removed in https://github.com/Simple-Station/Einstein-Engines/pull/1654, and reduced the weight of Teach a Lesson objective.

# Changelog

:cl: Skubman
- add: Re-enabled the kill objective for traitors.
- tweak: Reduced the chances of traitors getting the "Teach a Lesson" objective.
