### PR TITLE
Bluey SOP Modification

### DIFF
--- a/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/BlueshieldOfficerSOP.xml
+++ b/Resources/ServerInfo/Guidebook/SOP/Jobs/Dignitary/BlueshieldOfficerSOP.xml
@@ -11,6 +11,13 @@ This is the list of procedures, responsibilities, and duties of the [color=#1b67
 The [bold][color=#fcd12a]most important[/color][/bold] rule of the Blueshield Officer is to protect and maintain the lives of Command personnel on the station.
 <Box>Command personnel are personnel hired by Nanotrasen (confirmed personnel in command) and any Central Command officials (including BSO).</Box>
 
+<Box>~</Box>
+<Box>[bold][color=#1b67a5][head=2]Blueshield Priorities[/head][/color][/bold]</Box>
+<Box>Nuclear Authentication Disk</Box>
+<Box>Nanotrasen Representative & Captain</Box>
+<Box>Heads of Staff</Box>
+<Box>~</Box>
+
 1. The Blueshield Officer must listen to and follow orders of the NTR unless it would directly conflict with ensuring the safety of Command personnel or Central Command orders.
 
 2. The Blueshield Officer is to put the lives of Command over the lives of all others, including the Blueshield Officer. Their well-being is top priority.


### PR DESCRIPTION
# Description

Bluey now prioritizes the nuke disk first, NTR & Captain second, and then the other heads of staff third

---

# TODO

- [x] Adjust Bluey priorities in SOP

---

# Changelog

:cl: ShirouAjisai
- tweak: Adjusted Blueshield priorities in SOP