### PR TITLE
Fix .30 Uranium in Flight Name and Nerf Damage on Most Uranium Munitions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -47,12 +47,12 @@
 - type: entity
   id: BulletLightRifleUranium
   parent: BaseBulletUranium
-  name: bullet (.20 rifle uranium)
+  name: bullet (.30 rifle uranium)
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
-    damage:
+    damage: # hii durkkkkk
       types:
-        Radiation: 10
-        Piercing: 5
+        Radiation: 1.5
+        Piercing: 8.5
     ignoreResistances: true # Goob Station MRP - ignore resistances

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -52,6 +52,6 @@
   - type: Projectile # Goob Station - ignore resistances
     damage:
       types:
-        Radiation: 5
-        Piercing: 10
+        Radiation: 2.5 # maybe these shouldn't do 15 total as .35 auto - Ducks
+        Piercing: 5
     ignoreResistances: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -49,9 +49,9 @@
   name: bullet (0.20 rifle uranium)
   categories: [ HideSpawnMenu ]
   components:
-  - type: Projectile # Goob Station MRP - ignore resistances
-    damage:
+  - type: Projectile
+    damage: # GS MRP - nerf damage from 15 to 10 total, and slant towards piercing
       types:
-        Radiation: 10
-        Piercing: 5
-    ignoreResistances: true
+        Radiation: 1.5
+        Piercing: 8.5
+    ignoreResistances: true # Goob Station MRP - ignore resistances

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -214,8 +214,8 @@
   - type: Projectile # Goob Station - ignore resistances
     damage:
       types:
-        Radiation: 5
-        Piercing: 2.5
+        Radiation: 2.5
+        Piercing: 5
     ignoreResistances: true
 
 - type: entity


### PR DESCRIPTION
As per the desk of Durk "Adminbus" Gaming, i nerfed uranium munitions to hopefully somewhat balanced levels.

:cl: NT Munitions Testing (Ducks)
- tweak: Uranium munitions have been nerfed, and are more weighted towards piercing damage.
- remove: Removed "fun".
