### PR TITLE
Add .20 rifle rubber ammo box, missing age requirements to bartender loadout items

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Service/bartender.yml
@@ -39,6 +39,22 @@
     - MagazineBoxLightRifleRubber
 
 - type: loadout
+  id: LoadoutServiceBartenderBoxRifleRubber
+  category: JobsServiceBartender
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBartenderAmmo
+    - !type:CharacterJobRequirement
+      jobs:
+        - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
+  items:
+    - MagazineBoxRifleRubber
+
+- type: loadout
   id: LoadoutServiceBartenderShotgunDoubleBarreledRubber
   category: JobsServiceBartender
   cost: 0
@@ -81,6 +97,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - MagazineBoxMagnumRubber
 
@@ -95,6 +113,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponRevolverArgentiNonlethal
 
@@ -109,6 +129,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - Bartender
+    - !type:CharacterAgeRequirement
+      min: 21
   items:
     - WeaponSniperRepeaterNonlethal
 


### PR DESCRIPTION
# Description

Adds a .20 rifle rubber ammo box to the bartender loadout. This brings the Argenti in line with other bartender weapons which can come with extra ammo,
Also adds an age requirement to the Argenti, repeater rifle, and .45 magnum rubber ammo box to comply with space law.

---

# Changelog

:cl:
- add: Added .20 rifle rubber ammo box to bartender loadout
- add: Added age requirement to Argenti, repeater rifle, .45 magnum rubber ammo box
