### PR TITLE
Disable AAC Tablet Pending Rework™

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -782,12 +782,13 @@
   items:
     - DrinkVacuumFlask
 
-- type: loadout
-  id: LoadoutItemAACTablet
-  category: Items
-  cost: 2
-  items:
-    - AACTablet
+# Goobstation - Disable AAC tablet
+# - type: loadout
+#   id: LoadoutItemAACTablet
+#   category: Items
+#   cost: 2
+#   items:
+#     - AACTablet
 
 - type: loadout
   id: LoadoutItemCaneBlind


### PR DESCRIPTION
# Description

Removes the AAC tablet pending rework™.

## Why / Balance

Two problems:
- AAC tablet has no integration with the Language system, effectively making AAC users speak Universal, making it a one-way Xenoglossy while being way cheaper
- Not battery-powered unlike the translator

These two problems basically make AAC into free points for Mute characters.

## Changelog

:cl: Skubman
remove: The AAC tablet has been removed pending rework™.