### PR TITLE
No More Metempsychosis

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/metempsychoticMachine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/metempsychoticMachine.yml
@@ -5,7 +5,7 @@
   description: Speeds along the transmigration of a soul to its next vessel.
   components:
     - type: CloningPod
-      doMetempsychosis: true
+      doMetempsychosis: false
       biomassCostMultiplier: 0.5
     - type: Machine
       board: MetempsychoticMachineCircuitboard


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description
Removed the psionic requirement for successful cloning with the metem machine.
This would be a good change because cloning is one of medical's very few ways of dealing with radiation and with it having a high chance of spawning non-psionics into nonhumanoid bodies effectively round removes them unless medical jumps through hoops. 

 








---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/ZhfsEhBBBrA/0.jpg)](https://www.youtube.com/watch?v=ZhfsEhBBBrA)
</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Tonk
- tweak: The Metempsychosis Machine works with non-psionics now

