### PR TITLE
Temporarily Disables Bionic Leg

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -868,28 +868,28 @@
               Brute: -0.6
               Burn: -0.6
 
-- type: trait
-  id: BionicLeg
-  category: Physical
-  points: -6
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitReplaceComponent
-      components:
-      - type: TraitSpeedModifier
-        sprintModifier: 1.300
-        walkModifier: 1.125
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-bionic-leg-message
-          fontSize: 12
-          requireDetailRange: true
+# - type: trait
+#  id: BionicLeg
+#  category: Physical
+#  points: -6
+#  requirements:
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+#    - !type:CharacterItemGroupRequirement
+#      group: TraitsMind
+#  functions:
+#    - !type:TraitReplaceComponent
+#      components:
+#      - type: TraitSpeedModifier
+#        sprintModifier: 1.300
+#        walkModifier: 1.125
+#    - !type:TraitPushDescription
+#      descriptionExtensions:
+#        - description: examine-bionic-leg-message
+#          fontSize: 12
+#          requireDetailRange: true
 
 - type: trait
   id: FlareShieldingModule


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Temporarily comments out bionic leg, as the trait apparently bypasses crawl slowdowns which is a massive oversight, and probably could do with some overall tweaks to make it less of an OP must have trait.
