### PR TITLE
Enable the Config Var to Delete Characters with Illegal Trait Totals.

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -319,7 +319,7 @@ public sealed partial class CCVars
     ///     If you are intending to decrease the trait points availability, or modify the costs of traits, consider temporarily disabling this.
     /// </summary>
     public static readonly CVarDef<bool> TraitsPunishCheaters =
-        CVarDef.Create("game.traits_punish_cheaters", false, CVar.REPLICATED);
+        CVarDef.Create("game.traits_punish_cheaters", true, CVar.REPLICATED);
 
     /// <summary>
     ///     Whether to allow characters to select loadout items.


### PR DESCRIPTION
# Description

Enable the cvar that deletes your character after a bit if you spend more trait points compared to what you actually have, this should be enabled, as it is even mentioned in the FAQ on the discord, but it is not.

And before you say upstream it, they want it disabled by default, but enable-able by servers if they want it, and I think we want it.

PSA: Even with this CVar disabled, spawning with an illegal trait total still creates an admin log, so don't think you can go abusing this and not get caught.

---

# Changelog

:cl: BramvanZijp
- tweak: Characters that have spent more trait points than than they actually have will now be deleted again, with a slight delay.