### PR TITLE
Add a Global Playtime Requirement to Security Cadet

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -13,6 +13,8 @@
         - Blindness
         - Pacifist
         - BrittleBoneDisease
+    - !type:CharacterOverallTimeRequirement
+      min: 36000  # Goob - 10 hours
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"
   supervisors: job-supervisors-security


### PR DESCRIPTION
# Description

You can no longer play security cadet unless you have at least 10 hours of global playtime.
This fucks over raiders big time, and also prevents people with 0 clue wtf they are doing from immediately jumping into security, which is, 9/10 times, not fun for anybody involved. If you have experience on other servers, you can transfer in your security time from those servers and then just play as a security officer, so this is only really a problem/nerf for brand new people who want to go in way over their heads right away, but are now prevented from doing so (you're welcome), or for raiders (fuck you)

---

# Changelog

:cl: BramvanZijp
- add: Added a 10 hour global playtime requirement to the Security Cadet role.