### PR TITLE
Add Playtime Requirements to the Station AI.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -4,6 +4,12 @@
   name: job-name-station-ai
   description: job-description-station-ai
   playTimeTracker: JobStationAi
+  requirements:
+    - !type:CharacterOverallTimeRequirement
+      min: 180000 # Goob MRP - 50 Hours, easy to abuse both accidentally and deliberately.
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobBorg
+      min: 54000 # Goob MRP - 15 Hours, you need to know how silicon laws work.
   canBeAntag: false
   icon: JobIconStationAi
   supervisors: job-supervisors-rd


### PR DESCRIPTION
# Description

Title.
You need 30 hours to play borg, so 50 for AI seems fair.
Also, silicon law knowledge is critical, so 15 hours as borg too.

Station AI can easily ruin a round if you do not play it properly, so it should be a hard to unlock role.

---

# Changelog

:cl: BramvanZijp
- add: Added a playtime requirement to Station AI of 50 global hours and 15 borg hours.