### PR TITLE
Bionic Legs Now Cost 16 Points

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -886,7 +886,7 @@
 - type: trait
   id: BionicLeg
   category: Physical
-  points: -8
+  points: -16
   requirements:
     - !type:CharacterJobRequirement
       inverted: true


### PR DESCRIPTION
Bionic legs now cost 16 trait points to get.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Bionic legs now cost 16 trait points to use instead of the 8 to make the game more balanced. The trait is overpowered. It's a flat upgrade that is always useful every single second of being in the game 

---


---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: NoSugarPlumNovember
- tweak: Bionic legs now cost 16 points
