### PR TITLE
Edited Keys to HoP Headsets.

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Ears/headsets.yml
@@ -7,9 +7,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyService
-      - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      - EncryptionKeyStationMaster
 
 - type: entity
   parent: ClothingHeadsetAlt
@@ -19,9 +17,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyService
-      - EncryptionKeyCommand
-      - EncryptionKeyCommon
+      - EncryptionKeyStationMaster
   - type: Sprite
     sprite: DeltaV/Clothing/Ears/Headsets/service.rsi
   - type: Clothing


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR replaces the Head of Personnel's headset keys with a station master key, giving them full comms to befit their status as the second in the chain of command, along with their minor AA. Now the HoP can remain up to date with the station's situation so they are apprised when they inevitably have to replace the gibbed captain.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

</p>
</details>

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: HoP has all radio channels now.
