### PR TITLE
Update the Metashield

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -20,12 +20,12 @@
 
   ## Nuclear Operatives
 
-  The existence of Nuclear Operatives beyond a myth that no one would act on is shielded.
+  Nukies are considered propaganda by Nanotrasen, and crew isn't informed on them at all.
+  Posters seen on-station are ignored and called syndicate propaganda.
 
   The fact that the nuke disk must be protected and could be used by a bad actor to try to destroy the station is not shielded.
 
   The revealing condition for this shield is any of the following:
-  - discovering a blood red hardsuit
   - discovering a nuclear operative's shuttle
   - an operative name
   - a War Ops announcement
@@ -45,6 +45,54 @@
   - witnessing someone changing their appearance
   - being a changeling
 
+  ## Heretics
+
+  To normal people, heretics are generally unknown. Security and Command may be aware that a group of people following a rogue god exists, but it's an absurd reality.
+  This metashield prohibits normal players from knowing what runes or reality fractures are. Security may be suspicious of them. 
+
+  Knowledge about the ability of heretics is not shielded.
+
+  The revealing condition for this shield is any of the following:
+  - witnessing a crewmember drawing a rune  
+  - witnessing a crewmember harvesting a reality fracture 
+  - witnessing a crewmember using their powers
+
+  ## Zombies
+
+  Zombies are known galaxy-wide, but not as real-life, instead, as fiction.
+  Nuclear Operatives and Syndicate Agents are aware of Romerol and what it can do, but are prohibited of speaking about it publicly - unless they want their families to die. 
+
+  Revealing conditions to the "Zombie" Shield:
+  - You are a Nuclear Operative
+  - You are a Syndicate Agent
+  - You are a Zombie
+  - You have seen Zombies on the station
+
+  ## Infections
+
+  Zombies are known as extinct, they previously ravaged humanity hundreds of years ago in medieval times.
+  A cure was made, and is still held onto by chemists and Chief Medical Officers as a show of how long your family has been in the field.
+
+  Revealing conditions to the "Infections" Shield:
+  - You are a Chemist
+  - You are a Chief Medical Officer
+  - Zombies are announced to be real and station-wide
+
+  ## Deathsquad
+
+  Deathsquad is known to exist - per the posters on the station, but they are not known as a crew killsquad, instead known as an elite team sent into stations to handle extreme threats even the best of ERT Security leaders could handle.
+  The station's Nanotrasen Representative and Blueshield Officer are aware that Deathsquad is a crew killsquad, but are heavily prohibited to mention it, and will be dealt with after, or during, the shift.
+   
+  In private conversations, faxes, or phone calls, both BSO & NTR are advised to use the term 'Janitor Squad' to refer to the Deathsquad.
+  Crew can also choose to roleplay as if they've seen deathsquad movies, knowing limited aspects of their gear one would reasonably know watching an action-movie.
+
+  Revealing conditions to the "Deathsquad" Shield:
+  - Code Omnicron is called, nuking the station
+  - Code Epsilon is called, terminating contracts
+  - You are the Nanotrasen Representative (NTR)
+  - You are the Blueshield Officer (BSO)
+  - A Central Command Official (Non-NTR/BSO) mentions Deathsquad as a [bold]Killsquad[/bold]
+   
   ## Implanted Implants
 
   Implanted implants are shielded.
@@ -110,4 +158,5 @@
   - The fact that the Syndicate are enemies of Nanotrasen, and that they regularly attempt to send covert agents to spy on, sabotage, or attack Nanotrasen.
   - A character's typical appearance. Though you should keep in mind that multiple characters can share the same name.
   - The fact that the Syndicate have covert items capable of getting items to them, and that these items are known as uplinks.
+  - Wizards are not metashielded as the wizards federation is well rumoured about.
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -87,7 +87,7 @@
   Crew can also choose to roleplay as if they've seen deathsquad movies, knowing limited aspects of their gear one would reasonably know watching an action-movie.
 
   Revealing conditions to the "Deathsquad" Shield:
-  - Code Omnicron is called, nuking the station
+  - Code Omicron is called, nuking the station
   - Code Epsilon is called, terminating contracts
   - You are the Nanotrasen Representative (NTR)
   - You are the Blueshield Officer (BSO)


### PR DESCRIPTION
## About the PR
This PR updates the metashield following the admin discussion on what should be metashielded. This added new metashields for zombies, zombie infections, and Deathsquad.

## Why / Balance
Admin votes.

**Changelog**
:cl:
- add: Added Zombies, Zombie Infections, and Deathsquad Metashields.
- remove: Removed blood red hardsuit from Nukies Metashield.
- tweak: Changed Nuclear Operatives description in Metashield.