### PR TITLE
Fix Admin Command Flags, Fix Namespace for Invisibility Power

### DIFF
--- a/Content.Server/Administration/Toolshed/SpawnCorporateStampCommand.cs
+++ b/Content.Server/Administration/Toolshed/SpawnCorporateStampCommand.cs
@@ -16,7 +16,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Toolshed;
 
-[ToolshedCommand, AdminCommand(AdminFlags.Debug)]
+[ToolshedCommand, AdminCommand(AdminFlags.Spawn)]
 public sealed class SpawnCorporateStampCommand : ToolshedCommand
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLogManager = default!;

--- a/Content.Server/Administration/Toolshed/SpawnPassportCommand.cs
+++ b/Content.Server/Administration/Toolshed/SpawnPassportCommand.cs
@@ -9,7 +9,7 @@ using Content.Server.Mind;
 
 namespace Content.Server.Administration.Toolshed;
 
-[ToolshedCommand, AdminCommand(AdminFlags.Debug)]
+[ToolshedCommand, AdminCommand(AdminFlags.Spawn)]
 public sealed class SpawnPassportCommand : ToolshedCommand
 {
     private SharedPassportSystem? _passportSystem;

--- a/Content.Server/Administration/Toolshed/SpawnSpecificCorporateStampCommand.cs
+++ b/Content.Server/Administration/Toolshed/SpawnSpecificCorporateStampCommand.cs
@@ -16,7 +16,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Toolshed;
 
-[ToolshedCommand, AdminCommand(AdminFlags.Debug)]
+[ToolshedCommand, AdminCommand(AdminFlags.Spawn)]
 public sealed class SpawnSpecificCorporateStampCommand : ToolshedCommand
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLogManager = default!;

--- a/Content.Server/Psionics/Invisibility/PsionicInvisibilitySystem.cs
+++ b/Content.Server/Psionics/Invisibility/PsionicInvisibilitySystem.cs
@@ -6,6 +6,8 @@ using Robust.Shared.Player;
 using Robust.Server.GameObjects;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Psionics;
+using Content.Shared.Psionics.Abilities.PsionicInvisibility;
+
 
 namespace Content.Server.Psionics
 {

--- a/Content.Shared/Psionics/Abilities/PsionicInvisibility/PsionicInvisibilityPowerSystem.cs
+++ b/Content.Shared/Psionics/Abilities/PsionicInvisibility/PsionicInvisibilityPowerSystem.cs
@@ -1,19 +1,19 @@
-using Content.Shared.Actions;
 using Content.Shared.Abilities.Psionics;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Events;
 using Content.Shared.Damage;
-using Content.Shared.Stunnable;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
-using Content.Shared.Psionics;
-using Content.Shared.Actions.Events;
+using Content.Shared.Stunnable;
+using Content.Shared.Throwing;
+using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
-using Content.Shared.Interaction.Events;
-using Content.Shared.Weapons.Ranged.Events;
-using Content.Shared.Throwing;
 using Robust.Shared.Timing;
 
-namespace Content.Server.Abilities.Psionics;
+
+namespace Content.Shared.Psionics.Abilities.PsionicInvisibility;
 
 public sealed class PsionicInvisibilityPowerSystem : EntitySystem
 {


### PR DESCRIPTION
This PR fixes a namespace error in the PsionicInvisibilityPowerSystem according to what TCJ said I should do to fix it
It also fixes some admin commands having the wrong AdminFlags