### PR TITLE
Shuttle Tech Moved to T1

### DIFF
--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -134,7 +134,7 @@
     sprite: Structures/Shuttles/gyroscope.rsi
     state: base
   discipline: Industrial
-  tier: 2
+  tier: 1
   cost: 10000
   recipeUnlocks:
   - ShuttleConsoleCircuitboard


### PR DESCRIPTION

# Description

the industrial node shuttle tech is moved to t1, its not a very useful tech so it being a t1 makes more sense, plus it should allow shuttles to actually be made in a round



</p>
</details>


# Changelog


:cl: Capslfern
- tweak: shuttle tech moved to t1
