### PR TITLE
Fix Changeling Identification in Admin Overlay

### DIFF
--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -273,4 +273,5 @@
   - type: MindRole
     antagPrototype: Changeling
     exclusiveAntag: true
+    roleType: SoloAntagonist
   - type: ChangelingRole


### PR DESCRIPTION
# Description
In the F7 Admin Overlay - The Changeling mindrole did not have a roleType assigned causing it default to non-antagonist.

Added roleType: SoloAntagonist to mind_roles.yml (It was really this simple)



<h1>Media</h1>

![image](https://github.com/user-attachments/assets/ad9ac6bb-4f59-48b6-8142-d5cf9c1724f6)



---

# Changelog

:cl:
- fix: Changelings are now correctly identified as Solo Antagonists in the admin overlay!

